### PR TITLE
StatsUpAI revamp: data-driven content, site infra & CI automation

### DIFF
--- a/.github/workflows/statsupai-revamp.yml
+++ b/.github/workflows/statsupai-revamp.yml
@@ -1,0 +1,26 @@
+name: statsupai-revamp checks
+
+# Scoped to the revamp folder so it never runs on unrelated commits
+# (e.g. the daily cvocaloid-observatory dashboard updates).
+on:
+  push:
+    branches: ["**"]
+    paths: ["statsupai-revamp/**"]
+  pull_request:
+    paths: ["statsupai-revamp/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Site checks (JSON, links, HTML sanity, asset budget)
+        run: node statsupai-revamp/scripts/check.mjs
+      - name: HTML lint
+        run: npx --yes htmlhint@1 --config statsupai-revamp/.htmlhintrc "statsupai-revamp/**/*.html"

--- a/statsupai-revamp/.htmlhintrc
+++ b/statsupai-revamp/.htmlhintrc
@@ -1,0 +1,14 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": true,
+  "tag-pair": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "attr-no-duplication": true,
+  "title-require": true,
+  "doctype-html5": true,
+  "spec-char-escape": false,
+  "head-script-disabled": false
+}

--- a/statsupai-revamp/404.html
+++ b/statsupai-revamp/404.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found — StatsUpAI</title>
+  <meta name="robots" content="noindex">
+  <meta name="theme-color" content="#088080">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+<main id="main">
+  <section class="hero">
+    <div class="container" style="text-align:center">
+      <span class="eyebrow">404</span>
+      <h1>This page wandered off.</h1>
+      <p class="lead">The page you’re looking for doesn’t exist or has moved.</p>
+      <div class="btn-row" style="justify-content:center">
+        <a class="btn btn-primary" href="index.html">Back to home</a>
+        <a class="btn btn-ghost" href="events.html">See upcoming webinars</a>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/statsupai-revamp/AUDIT.md
+++ b/statsupai-revamp/AUDIT.md
@@ -83,8 +83,41 @@ that won't match the quicksand filter cleanly.
 - **No iframe** for community content — direct, indexable, shareable links.
 - Consistent header/footer + ASA banner that sits in normal flow (no overlap).
 
-### Known limitation
+## Round 2 — deeper sweep (infra → operations → automation)
 
-Headshots were copied as-is from the mirror (the environment has no image tooling).
-A production pass should re-encode them to WebP/AVIF and add `srcset`. Content and
-team data should be re-synced from `Statsup-AI/statsupai.github.io`.
+The first round fixed the *presentation* layer. A site for a mass academic
+group also has to be **operable by non-engineers** and **safe to change**.
+Further suboptimal traits found and addressed:
+
+| # | Trait (any layer) | Severity | Addressed by |
+|---|-------------------|----------|--------------|
+|13 | Content baked into markup — adding a weekly webinar meant editing HTML | High | `assets/data/events.json` + client render; auto upcoming/past split |
+|14 | Datasets/articles/pipelines hand-coded as card markup | High | `assets/data/resources.json` + render with search & topic filter |
+|15 | No CI / validation — a stray comma or 12 MB image ships unnoticed | High | `scripts/check.mjs` + path-scoped GitHub Actions + htmlhint |
+|16 | No asset-weight guardrail (root cause of the original 129 MB `img/`) | High | Budget gate in `check.mjs` (per-file + `assets/img` total) |
+|17 | Webinars had no calendar export / no upcoming-vs-past logic | Med | Generated `.ics` "Add to calendar"; date-driven partition |
+|18 | No `Event`/`Organization` structured data (no Google event rich results) | Med | JSON-LD `Organization` (home) + `Event`/`ItemList` (rendered) |
+|19 | Missing site essentials: `sitemap.xml`, `robots.txt`, `404.html`, manifest, favicon, OG image | Med | All added (favicon/OG as lightweight SVG) |
+|20 | Analytics dropped vs. original, or would track preview/forks if re-added | Med | `analytics.js`: off by default, prod-host-only, honors DNT, `anonymize_ip` |
+|21 | No maintainer documentation for a non-technical academic team | Med | `MAINTAINING.md` — "edit one JSON file, commit, robots verify" |
+|22 | No no-JS/SEO fallback once content is client-rendered | Med | `<noscript>` link lists on every data-driven page |
+|23 | Repo hygiene in source: `.DS_Store`, `_Rhistory`, `.backup/`, ~1.7k tracked files | Low | N/A here — flagged for upstream cleanup |
+
+### Net effect
+
+- Adding a webinar or dataset is now a **one-file JSON edit** with automated
+  validation — appropriate for a rotating set of academic volunteers.
+- The class of regression that produced a single 11.7 MB hero image is now a
+  **hard build failure**, not a thing someone has to notice in review.
+- Search/filter, calendar export and date-aware scheduling match how the
+  audience actually uses an academic seminar site.
+
+### Known limitations
+
+- Headshots are the original unoptimized files (no image tooling in this
+  environment). Re-encode to WebP/AVIF + `srcset`, then tighten the asset
+  budget (see `MAINTAINING.md`).
+- `robots.txt` / `sitemap.xml` / `404.html` only take effect at a domain
+  root; they are inert while served from the `/statsupai-revamp/` subfolder.
+- Content and team data should be re-synced from the canonical
+  `Statsup-AI/statsupai.github.io` (outside this environment's repo scope).

--- a/statsupai-revamp/MAINTAINING.md
+++ b/statsupai-revamp/MAINTAINING.md
@@ -1,0 +1,74 @@
+# Maintaining the StatsUpAI site (for non-technical maintainers)
+
+You almost never touch HTML. Content lives in **JSON data files**; the site
+renders itself. Edit a file on GitHub, commit, and the automated checks +
+GitHub Pages do the rest.
+
+## Add or update a webinar
+
+Edit **`assets/data/events.json`** → add an object to `talks`:
+
+```json
+{
+  "date": "2026-03-04",
+  "time_et": "12:00 PM",
+  "duration_min": 60,
+  "speaker": "Jane Doe",
+  "affiliation": "MIT",
+  "title": "Talk title here",
+  "series": "GenAI",
+  "registration_link": "https://…/register",
+  "recording_link": ""
+}
+```
+
+- `series` must be `"Health"` or `"GenAI"`.
+- The page **auto-sorts** into *Upcoming* vs *Past* by today's date — no manual moving.
+- An **Add to calendar** (`.ics`) button is generated automatically.
+- After a talk, paste the YouTube/recording URL into `recording_link`; it
+  flips to a **Watch recording** button.
+
+## Add a dataset / review article / pipeline
+
+Edit **`assets/data/resources.json`** → add an object to `datasets`,
+`articles`, or `pipelines`:
+
+```json
+{ "title": "New Resource", "tag": "Genomics", "url": "https://…", "desc": "One sentence." }
+```
+
+The page rebuilds its cards, search box and topic filters from this file.
+
+## Add or change a team member
+
+Edit **`assets/js/team-data.js`** (one array). The card grid and the A–Z
+roster both render from it.
+
+## What the robots can do for you
+
+Every change is checked automatically (`.github/workflows/statsupai-revamp.yml`):
+
+- JSON files must parse (a missing comma is caught before it ships).
+- No broken internal links.
+- Each page keeps one `<h1>`, a title, and canonical URL.
+- **Asset-weight budget**: build fails if any file is too large — this is the
+  guardrail that prevents the old site's 12 MB-image problem from returning.
+
+If a check fails, the commit/PR shows a red ✗ with the exact reason.
+
+## Known follow-ups (need image tooling, not available here)
+
+- Team headshots are the original unoptimized files (some ~0.8 MB). Re-encode
+  to **WebP ~120 KB**, add `srcset`, then tighten `MAX_ASSET` in
+  `scripts/check.mjs` from 900 KB down to ~120 KB.
+- Generate a raster `og.png` from `assets/img/og.svg` (some scrapers ignore SVG OG).
+
+## Deployment notes
+
+This revamp is a self-contained static site. For the preview it lives at
+`https://yulinl2.github.io/statsupai-revamp/`. When promoted to the
+`statsupai.org` domain root, `robots.txt`, `sitemap.xml` and `404.html`
+become active automatically (they only work from a domain root, not a
+subfolder). To turn on analytics, set `MEASUREMENT_ID` in
+`assets/js/analytics.js` (it stays off on preview/fork hosts and honors
+Do Not Track).

--- a/statsupai-revamp/articles.html
+++ b/statsupai-revamp/articles.html
@@ -7,6 +7,11 @@
   <meta name="description" content="A curated library of review articles across cancer, EHR, genetics, medical imaging and microbiome, plus AI topic lists on LLMs, AI safety and AI agents.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/articles.html">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -41,62 +46,19 @@
 
   <section class="block">
     <div class="container">
-      <div class="section-head"><div class="kicker">Domain reviews</div><h2>By research area</h2></div>
-      <div class="grid cols-3">
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Cancer_review_papers.html" target="_blank" rel="noopener">Cancer Research</a></h3>
-          <p>Key discoveries in cancer genomes over 15 years, plus major genomic data
-          resources including PCAWG and TCGA and single-cell cancer databases.</p>
-          <ul class="tag-row"><li class="tag">PCAWG</li><li class="tag">TCGA</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/ehr_review_papers.html" target="_blank" rel="noopener">Electronic Health Records</a></h3>
-          <p>Papers, books and repositories on EHR — from real-world-evidence data prep to
-          advanced statistical and ML analysis.</p>
-          <ul class="tag-row"><li class="tag">EHR</li><li class="tag">RWE</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/genetic_review_papers.html" target="_blank" rel="noopener">Genetics</a></h3>
-          <p>GWAS, rare-variant analysis, polygenic risk scores and genomics–proteomics
-          integration linked to UK Biobank and All of Us.</p>
-          <ul class="tag-row"><li class="tag">GWAS</li><li class="tag">PRS</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Neuroimaging_review_papers.html" target="_blank" rel="noopener">Medical Imaging</a></h3>
-          <p>Reviews on medical-imaging preprocessing methods, theoretical challenges and
-          practical neuroscientific applications.</p>
-          <ul class="tag-row"><li class="tag">Imaging</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Microbiome_review_paper.html" target="_blank" rel="noopener">Microbiome &amp; Metagenomics</a></h3>
-          <p>Microbiota–gut–brain axis, the microbiome in aging and cancer, and
-          metagenomics for personalized medicine.</p>
-          <ul class="tag-row"><li class="tag">Microbiome</li></ul>
-        </article>
-      </div>
-
-      <hr class="div">
-
-      <div class="section-head"><div class="kicker">AI topic lists</div><h2>LLMs, safety &amp; agents</h2></div>
-      <div class="grid cols-3">
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/paper_list_ai/list-AI-LLM.html" target="_blank" rel="noopener">Large Language Models</a></h3>
-          <p>Techniques &amp; architectures, surveys (2023–2025), technical reports, trustworthy
-          LLM design and LLM-empowered statistical analysis.</p>
-          <ul class="tag-row"><li class="tag">LLM</li><li class="tag">Surveys</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/paper_list_ai/list-AI-Safety.html" target="_blank" rel="noopener">Safety &amp; Trustworthiness</a></h3>
-          <p>Algorithmic fairness &amp; bias, privacy &amp; differential privacy, and aligning AI
-          with human values.</p>
-          <ul class="tag-row"><li class="tag">Fairness</li><li class="tag">Privacy</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/paper_list_ai/list-AI-Agent.html" target="_blank" rel="noopener">AGI &amp; AI Agents</a></h3>
-          <p>The frontier of AGI and the explosion of AI agents — a foundational entry point
-          for statisticians new to the field.</p>
-          <ul class="tag-row"><li class="tag">Agents</li><li class="tag">AGI</li></ul>
-        </article>
+      <div data-resources="articles">
+        <noscript>
+          <ul>
+            <li><a href="https://statsupai.org/pages/Cancer_review_papers.html">Cancer Research</a></li>
+            <li><a href="https://statsupai.org/pages/ehr_review_papers.html">Electronic Health Records</a></li>
+            <li><a href="https://statsupai.org/pages/genetic_review_papers.html">Genetics</a></li>
+            <li><a href="https://statsupai.org/pages/Neuroimaging_review_papers.html">Medical Imaging</a></li>
+            <li><a href="https://statsupai.org/pages/Microbiome_review_paper.html">Microbiome &amp; Metagenomics</a></li>
+            <li><a href="https://statsupai.org/pages/paper_list_ai/list-AI-LLM.html">Large Language Models</a></li>
+            <li><a href="https://statsupai.org/pages/paper_list_ai/list-AI-Safety.html">AI Safety &amp; Trustworthiness</a></li>
+            <li><a href="https://statsupai.org/pages/paper_list_ai/list-AI-Agent.html">AGI &amp; AI Agents</a></li>
+          </ul>
+        </noscript>
       </div>
     </div>
   </section>
@@ -117,6 +79,8 @@
   </div>
 </footer>
 
+<script src="assets/js/render.js" defer></script>
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/assets/css/main.css
+++ b/statsupai-revamp/assets/css/main.css
@@ -321,3 +321,27 @@ section.block.soft { background: var(--bg-soft); }
 .prose p { max-width: 72ch; }
 .lead-block { max-width: 70ch; font-size: 1.1rem; color: var(--body); }
 hr.div { border: 0; height: 1px; background: var(--line); margin: 48px 0; }
+
+/* ---------- Resource search / filter ---------- */
+.res-controls { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; margin-bottom: 28px; }
+.res-search {
+  flex: 1 1 260px; min-width: 220px;
+  padding: 11px 15px; font: inherit; color: var(--ink);
+  background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+}
+.res-search::placeholder { color: var(--muted); }
+.res-filters { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  font: inherit; font-size: .86rem; cursor: pointer;
+  padding: 7px 13px; border-radius: 999px;
+  background: var(--bg-soft); color: var(--body);
+  border: 1px solid var(--line);
+}
+.chip:hover { border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); }
+.chip.on { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); }
+.res-empty { color: var(--muted); }
+
+/* ---------- Event actions ---------- */
+.event-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+.btn-sm { padding: 8px 14px; font-size: .9rem; border-radius: 9px; }
+.event-actions .meta { align-self: center; }

--- a/statsupai-revamp/assets/data/events.json
+++ b/statsupai-revamp/assets/data/events.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "SINGLE SOURCE OF TRUTH for webinars. Non-technical maintainers: add an object, commit. CI validates it; the site auto-sorts upcoming vs past by date and builds calendar links. Date = ISO YYYY-MM-DD. time_et like '12:00 PM'. series = 'Health' | 'GenAI'.",
+  "series": {
+    "Health": { "label": "Health Data Science Series", "tagline": "Big-data & AI methods for health, imaging, genetics and clinical phenotyping." },
+    "GenAI": { "label": "GenAI × Statistics Series", "tagline": "Bridging the gap between generative AI and statistical methodologies." }
+  },
+  "talks": [
+    {
+      "date": "2026-01-09",
+      "time_et": "12:00 PM",
+      "duration_min": 60,
+      "speaker": "Andrew Saykin",
+      "affiliation": "Indiana University School of Medicine",
+      "title": "Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine",
+      "series": "Health",
+      "registration_link": "https://upenn.zoom.us/meeting/register/uA1Jh_J8T3Wez4q0rbpTLQ#/registration",
+      "recording_link": ""
+    },
+    {
+      "date": "2026-01-16",
+      "time_et": "12:00 PM",
+      "duration_min": 60,
+      "speaker": "Mine Çetinkaya-Rundel",
+      "affiliation": "Duke University",
+      "title": "Leveraging LLMs for student feedback in introductory data science courses",
+      "series": "GenAI",
+      "registration_link": "https://upenn.zoom.us/meeting/register/7iwjCrS6Qia0EbrBodLyQw#/registration",
+      "recording_link": ""
+    },
+    {
+      "date": "2026-02-11",
+      "time_et": "1:00 PM",
+      "duration_min": 60,
+      "speaker": "James Zou",
+      "affiliation": "Stanford University",
+      "title": "AI agents to accelerate scientific discoveries",
+      "series": "GenAI",
+      "registration_link": "https://sfu.zoom.us/meeting/register/3MLcnkc9TJCYfHNrdVSbeQ#/registration",
+      "recording_link": ""
+    }
+  ]
+}

--- a/statsupai-revamp/assets/data/resources.json
+++ b/statsupai-revamp/assets/data/resources.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "SINGLE SOURCE OF TRUTH for Datasets / Review Articles / Pipelines. Edit one file, commit. CI validates JSON; pages render + search client-side, with a no-JS fallback list.",
+  "datasets": [
+    { "title": "Genomics Data", "tag": "Genomics", "url": "https://odin.mdacc.tmc.edu/~wwang7/data_resources.html", "desc": "Genome-scale resources for method development in oncology and population genetics." },
+    { "title": "Medical Imaging Data", "tag": "Imaging", "url": "https://statsupai.org/pages/neuroimaging2.html", "desc": "Brain and medical imaging datasets for preprocessing and analysis pipelines." },
+    { "title": "Microbiome & Metagenomics", "tag": "Microbiome", "url": "https://statsupai.org/pages/micro2.html", "desc": "Microbiome and metagenomic collections for community and gut–brain studies." },
+    { "title": "EHR Data", "tag": "EHR", "url": "https://statsupai.org/pages/data_ehr.html", "desc": "Electronic Health Record data for real-world evidence and predictive modeling." },
+    { "title": "Clinical Trial Data", "tag": "Clinical Trial", "url": "https://statsupai.org/pages/clinicaltrial.html", "desc": "Clinical-trial datasets to support causal inference and trial methodology." },
+    { "title": "Biobank Data", "tag": "Biobank", "url": "https://statsupai.org/pages/biobank_dataset.html", "desc": "Large-scale biobank resources such as UK Biobank–style population cohorts." },
+    { "title": "Spatial Transcriptomics", "tag": "Spatial omics", "url": "https://statsupai.org/pages/Omics_data.html", "desc": "Spatially resolved transcriptomics datasets for tissue-level analysis." },
+    { "title": "Proteomics Data", "tag": "Proteomics", "url": "https://statsupai.org/pages/Proteogenomics.html", "desc": "Proteomic and proteogenomic resources linking protein and genomic layers." },
+    { "title": "Bioinformatics Data", "tag": "Bioinformatics", "url": "https://statsupai.org/pages/bioinformatics.html", "desc": "General-purpose bioinformatics datasets and tooling references." }
+  ],
+  "articles": [
+    { "title": "Cancer Research", "tag": "Cancer", "url": "https://statsupai.org/pages/Cancer_review_papers.html", "desc": "Key discoveries in cancer genomes over 15 years, plus PCAWG, TCGA and single-cell cancer databases." },
+    { "title": "Electronic Health Records", "tag": "EHR", "url": "https://statsupai.org/pages/ehr_review_papers.html", "desc": "Papers, books and repositories on EHR — from real-world-evidence data prep to advanced statistical/ML analysis." },
+    { "title": "Genetics", "tag": "Genetics", "url": "https://statsupai.org/pages/genetic_review_papers.html", "desc": "GWAS, rare-variant analysis, polygenic risk scores and genomics–proteomics integration." },
+    { "title": "Medical Imaging", "tag": "Imaging", "url": "https://statsupai.org/pages/Neuroimaging_review_papers.html", "desc": "Reviews on medical-imaging preprocessing methods and practical neuroscientific applications." },
+    { "title": "Microbiome & Metagenomics", "tag": "Microbiome", "url": "https://statsupai.org/pages/Microbiome_review_paper.html", "desc": "Microbiota–gut–brain axis, the microbiome in aging and cancer, metagenomics for personalized medicine." },
+    { "title": "Large Language Models", "tag": "AI", "url": "https://statsupai.org/pages/paper_list_ai/list-AI-LLM.html", "desc": "Techniques & architectures, surveys, trustworthy-LLM design and LLM-empowered statistical analysis." },
+    { "title": "AI Safety & Trustworthiness", "tag": "AI", "url": "https://statsupai.org/pages/paper_list_ai/list-AI-Safety.html", "desc": "Algorithmic fairness & bias, privacy & differential privacy, aligning AI with human values." },
+    { "title": "AGI & AI Agents", "tag": "AI", "url": "https://statsupai.org/pages/paper_list_ai/list-AI-Agent.html", "desc": "The frontier of AGI and AI agents — a foundational entry point for statisticians new to the field." }
+  ],
+  "pipelines": [
+    { "title": "EHR Data Pipelines", "tag": "EHR", "url": "https://github.com/data-processing-pipeline/EHR_data_pipelines/tree/main", "desc": "Pipelines for processing Electronic Health Record data, from ingestion to analysis-ready datasets." },
+    { "title": "Neuroimaging Processing Software", "tag": "Imaging", "url": "https://statsupai.org/pages/Neuroimaging%20Processing%20Software.html", "desc": "Key neuroimaging tools widely used in neuroscience research, with corresponding publications." },
+    { "title": "Data Fusion Analysis Pipeline", "tag": "Multi-modal", "url": "https://statsupai.org/pages/Data_Fusion_Analysis_Pipeline_pipeline.html", "desc": "A modular framework integrating diverse data sources and analytical models." },
+    { "title": "Clinical Trials Data Processing", "tag": "Clinical Trial", "url": "https://statsupai.org/pages/clinicaltrials_pipeline.html", "desc": "Efficient pipelines for processing and analyzing clinical-trial data." }
+  ]
+}

--- a/statsupai-revamp/assets/img/favicon.svg
+++ b/statsupai-revamp/assets/img/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="StatsUpAI">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a9c9c"/>
+      <stop offset="1" stop-color="#0a6b6b"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)"/>
+  <path d="M14 40 L26 28 L36 36 L50 20" fill="none" stroke="#fff" stroke-width="5"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="50" cy="20" r="4.5" fill="#fff"/>
+</svg>

--- a/statsupai-revamp/assets/img/og.svg
+++ b/statsupai-revamp/assets/img/og.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="StatsUpAI — Statistics shaping the future of AI">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0c1413"/>
+      <stop offset="1" stop-color="#073b3b"/>
+    </linearGradient>
+    <linearGradient id="m" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a9c9c"/>
+      <stop offset="1" stop-color="#0a6b6b"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g opacity="0.18" stroke="#0a9c9c" stroke-width="2">
+    <path d="M120 470 L300 360 L440 420 L640 250 L820 320 L1040 170" fill="none"/>
+  </g>
+  <rect x="90" y="90" width="64" height="64" rx="16" fill="url(#m)"/>
+  <text x="106" y="135" font-family="system-ui,Arial" font-size="38" font-weight="800" fill="#fff">S</text>
+  <text x="176" y="138" font-family="system-ui,Arial" font-size="40" font-weight="800" fill="#eaf3f1">StatsUpAI</text>
+  <text x="90" y="330" font-family="system-ui,Arial" font-size="74" font-weight="800" fill="#eaf3f1">Statistics shaping the</text>
+  <text x="90" y="420" font-family="system-ui,Arial" font-size="74" font-weight="800" fill="#0a9c9c">future of AI.</text>
+  <text x="90" y="500" font-family="system-ui,Arial" font-size="32" fill="#9fb6b3">An ASA interest group · datasets · reviews · pipelines · webinars</text>
+</svg>

--- a/statsupai-revamp/assets/js/analytics.js
+++ b/statsupai-revamp/assets/js/analytics.js
@@ -1,0 +1,22 @@
+/* Privacy-respecting analytics loader.
+   Disabled by default. To enable on the production domain, set MEASUREMENT_ID
+   to the GA4 id (the original site used "G-ZF2MZCZ03F"). Honors Do Not Track
+   and only loads on the production host so preview/forks don't pollute stats. */
+(function () {
+  "use strict";
+  var MEASUREMENT_ID = "";                       // e.g. "G-ZF2MZCZ03F"
+  var PROD_HOSTS = ["statsupai.org", "www.statsupai.org"];
+
+  if (!MEASUREMENT_ID) return;
+  if (navigator.doNotTrack === "1" || window.doNotTrack === "1") return;
+  if (PROD_HOSTS.indexOf(location.hostname) === -1) return;
+
+  var s = document.createElement("script");
+  s.async = true;
+  s.src = "https://www.googletagmanager.com/gtag/js?id=" + MEASUREMENT_ID;
+  document.head.appendChild(s);
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+  gtag("js", new Date());
+  gtag("config", MEASUREMENT_ID, { anonymize_ip: true });
+})();

--- a/statsupai-revamp/assets/js/render.js
+++ b/statsupai-revamp/assets/js/render.js
@@ -1,0 +1,208 @@
+/* Data-driven rendering for resources (datasets/articles/pipelines) and events.
+   Single source: assets/data/*.json. Progressive enhancement — static
+   <noscript> fallbacks in the HTML stay crawlable if this never runs. */
+(function () {
+  "use strict";
+
+  function el(tag, cls, html) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (html != null) n.innerHTML = html;
+    return n;
+  }
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+  function getJSON(path) {
+    return fetch(path, { cache: "no-cache" }).then(function (r) {
+      if (!r.ok) throw new Error(path + " " + r.status);
+      return r.json();
+    });
+  }
+
+  /* ---------------- Resources (search + filter) ---------------- */
+  var resRoot = document.querySelector("[data-resources]");
+  if (resRoot) {
+    var kind = resRoot.getAttribute("data-resources"); // datasets|articles|pipelines
+    getJSON("assets/data/resources.json").then(function (data) {
+      var items = data[kind] || [];
+      var tags = ["All"].concat(
+        items.map(function (i) { return i.tag; })
+          .filter(function (v, i, a) { return a.indexOf(v) === i; })
+      );
+
+      var controls = el("div", "res-controls");
+      var search = el("input", "res-search");
+      search.type = "search";
+      search.placeholder = "Search " + kind + "…";
+      search.setAttribute("aria-label", "Search " + kind);
+      var filterWrap = el("div", "res-filters");
+      filterWrap.setAttribute("role", "group");
+      filterWrap.setAttribute("aria-label", "Filter by topic");
+      controls.appendChild(search);
+      controls.appendChild(filterWrap);
+
+      var grid = el("div", "grid cols-3");
+      resRoot.innerHTML = "";
+      resRoot.appendChild(controls);
+      resRoot.appendChild(grid);
+      var empty = el("p", "res-empty", "No matches. Try a different search.");
+      empty.hidden = true;
+      resRoot.appendChild(empty);
+
+      var activeTag = "All", q = "";
+      tags.forEach(function (t) {
+        var b = el("button", "chip" + (t === "All" ? " on" : ""), esc(t));
+        b.type = "button";
+        b.addEventListener("click", function () {
+          activeTag = t;
+          filterWrap.querySelectorAll(".chip").forEach(function (c) { c.classList.remove("on"); });
+          b.classList.add("on");
+          paint();
+        });
+        filterWrap.appendChild(b);
+      });
+
+      function paint() {
+        grid.innerHTML = "";
+        var shown = items.filter(function (i) {
+          var matchTag = activeTag === "All" || i.tag === activeTag;
+          var hay = (i.title + " " + i.desc + " " + i.tag).toLowerCase();
+          return matchTag && hay.indexOf(q) !== -1;
+        });
+        empty.hidden = shown.length !== 0;
+        shown.forEach(function (i) {
+          var c = el("article", "card");
+          c.innerHTML =
+            '<h3><a href="' + esc(i.url) + '" target="_blank" rel="noopener">' + esc(i.title) + "</a></h3>" +
+            "<p>" + esc(i.desc) + "</p>" +
+            '<ul class="tag-row"><li class="tag">' + esc(i.tag) + "</li></ul>" +
+            '<a class="more" href="' + esc(i.url) + '" target="_blank" rel="noopener">Open resource</a>';
+          grid.appendChild(c);
+        });
+      }
+      search.addEventListener("input", function () { q = search.value.trim().toLowerCase(); paint(); });
+      paint();
+
+      // ItemList JSON-LD for crawlers
+      var ld = {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        name: "StatsUpAI " + kind,
+        itemListElement: items.map(function (i, n) {
+          return { "@type": "ListItem", position: n + 1, url: i.url, name: i.title };
+        })
+      };
+      var s = el("script");
+      s.type = "application/ld+json";
+      s.textContent = JSON.stringify(ld);
+      document.head.appendChild(s);
+    }).catch(function () { /* keep noscript fallback */ });
+  }
+
+  /* ---------------- Events ---------------- */
+  var evRoot = document.getElementById("events-root");
+  if (evRoot) {
+    getJSON("assets/data/events.json").then(function (data) {
+      var today = new Date();
+      today.setHours(0, 0, 0, 0);
+      var talks = (data.talks || []).slice().sort(function (a, b) {
+        return a.date < b.date ? -1 : 1;
+      });
+      var upcoming = [], past = [];
+      talks.forEach(function (t) {
+        (new Date(t.date + "T00:00:00") >= today ? upcoming : past).push(t);
+      });
+      past.reverse();
+
+      function fmt(d) {
+        return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+          month: "short", day: "numeric", year: "numeric"
+        });
+      }
+      function ics(t) {
+        var start = t.date.replace(/-/g, "");
+        var lines = [
+          "BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//StatsUpAI//EN",
+          "BEGIN:VEVENT",
+          "UID:" + start + "-" + encodeURIComponent(t.speaker) + "@statsupai.org",
+          "DTSTART;VALUE=DATE:" + start,
+          "SUMMARY:" + t.title.replace(/[,;]/g, "") + " — " + t.speaker,
+          "DESCRIPTION:" + (data.series[t.series] ? data.series[t.series].label : t.series) +
+            (t.registration_link ? "\\nRegister: " + t.registration_link : ""),
+          "END:VEVENT", "END:VCALENDAR"
+        ];
+        return "data:text/calendar;charset=utf-8," + encodeURIComponent(lines.join("\r\n"));
+      }
+      function card(t, isUpcoming) {
+        var ser = data.series[t.series] ? data.series[t.series].label : t.series;
+        var actions = isUpcoming
+          ? (t.registration_link
+              ? '<a class="btn btn-primary btn-sm" href="' + esc(t.registration_link) + '" target="_blank" rel="noopener">Register</a>'
+              : "") +
+            '<a class="btn btn-ghost btn-sm" href="' + ics(t) + '" download="statsupai-' + t.date + '.ics">Add to calendar</a>'
+          : (t.recording_link
+              ? '<a class="btn btn-ghost btn-sm" href="' + esc(t.recording_link) + '" target="_blank" rel="noopener">Watch recording</a>'
+              : '<span class="meta">Recording TBA</span>');
+        var d = el("div", "event");
+        d.innerHTML =
+          '<span class="date">' + fmt(t.date) + " · " + esc(t.time_et) + " ET</span>" +
+          '<span class="badge">' + esc(t.series) + "</span>" +
+          "<h3>" + esc(t.title) + "</h3>" +
+          '<p class="meta">' + esc(t.speaker) + " · " + esc(t.affiliation) + " · <em>" + esc(ser) + "</em></p>" +
+          '<div class="event-actions">' + actions + "</div>";
+        return d;
+      }
+
+      var html = "";
+      var up = el("div");
+      up.appendChild(el("div", "section-head",
+        '<div class="kicker">Upcoming</div><h2>Next talks</h2>'));
+      if (upcoming.length) {
+        var tl = el("div", "timeline");
+        upcoming.forEach(function (t) { tl.appendChild(card(t, true)); });
+        up.appendChild(tl);
+      } else {
+        up.appendChild(el("p", "meta", "No upcoming talks scheduled — check back soon."));
+      }
+
+      var pa = el("div");
+      pa.style.marginTop = "48px";
+      pa.appendChild(el("div", "section-head",
+        '<div class="kicker">Archive</div><h2>Past talks</h2>'));
+      if (past.length) {
+        var tl2 = el("div", "timeline");
+        past.forEach(function (t) { tl2.appendChild(card(t, false)); });
+        pa.appendChild(tl2);
+      } else {
+        pa.appendChild(el("p", "meta", "Archive coming soon."));
+      }
+
+      evRoot.innerHTML = "";
+      evRoot.appendChild(up);
+      evRoot.appendChild(pa);
+
+      // Event JSON-LD (Google event rich results)
+      var ld = talks.map(function (t) {
+        return {
+          "@context": "https://schema.org",
+          "@type": "Event",
+          name: t.title,
+          startDate: t.date,
+          eventAttendanceMode: "https://schema.org/OnlineEventAttendanceMode",
+          eventStatus: "https://schema.org/EventScheduled",
+          location: { "@type": "VirtualLocation", url: t.registration_link || "https://statsupai.org/events/webinars/" },
+          organizer: { "@type": "Organization", name: "StatsUpAI", url: "https://statsupai.org" },
+          performer: { "@type": "Person", name: t.speaker },
+          description: (data.series[t.series] ? data.series[t.series].label : t.series)
+        };
+      });
+      var s = el("script");
+      s.type = "application/ld+json";
+      s.textContent = JSON.stringify(ld);
+      document.head.appendChild(s);
+    }).catch(function () { /* keep noscript fallback */ });
+  }
+})();

--- a/statsupai-revamp/community.html
+++ b/statsupai-revamp/community.html
@@ -7,6 +7,11 @@
   <meta name="description" content="Funding, awards and training opportunities for statisticians in AI, plus interviews and annual newsletters from the StatsUpAI community.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/community-news.html">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -92,6 +97,7 @@
   </div>
 </footer>
 
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/datasets.html
+++ b/statsupai-revamp/datasets.html
@@ -7,6 +7,11 @@
   <meta name="description" content="Curated, well-organized datasets for statisticians across EHR, genomics, imaging, microbiome, clinical trials, biobanks, spatial transcriptomics, proteomics and bioinformatics.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/datasets.html">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -40,52 +45,20 @@
 
   <section class="block">
     <div class="container">
-      <div class="grid cols-3">
-        <article class="card">
-          <h3><a href="https://odin.mdacc.tmc.edu/~wwang7/data_resources.html" target="_blank" rel="noopener">Genomics Data</a></h3>
-          <p>Genome-scale resources for method development in oncology and population genetics.</p>
-          <ul class="tag-row"><li class="tag">Genomics</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/neuroimaging2.html" target="_blank" rel="noopener">Medical Imaging Data</a></h3>
-          <p>Brain and medical imaging datasets for preprocessing and analysis pipelines.</p>
-          <ul class="tag-row"><li class="tag">Imaging</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/micro2.html" target="_blank" rel="noopener">Microbiome &amp; Metagenomics</a></h3>
-          <p>Microbiome and metagenomic collections for community and gut–brain studies.</p>
-          <ul class="tag-row"><li class="tag">Microbiome</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/data_ehr.html" target="_blank" rel="noopener">EHR Data</a></h3>
-          <p>Electronic Health Record data for real-world evidence and predictive modeling.</p>
-          <ul class="tag-row"><li class="tag">EHR</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/clinicaltrial.html" target="_blank" rel="noopener">Clinical Trial Data</a></h3>
-          <p>Clinical-trial datasets to support causal inference and trial methodology.</p>
-          <ul class="tag-row"><li class="tag">Clinical Trial</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/biobank_dataset.html" target="_blank" rel="noopener">Biobank Data</a></h3>
-          <p>Large-scale biobank resources such as UK Biobank–style population cohorts.</p>
-          <ul class="tag-row"><li class="tag">Biobank</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Omics_data.html" target="_blank" rel="noopener">Spatial Transcriptomics</a></h3>
-          <p>Spatially resolved transcriptomics datasets for tissue-level analysis.</p>
-          <ul class="tag-row"><li class="tag">Spatial omics</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Proteogenomics.html" target="_blank" rel="noopener">Proteomics Data</a></h3>
-          <p>Proteomic and proteogenomic resources linking protein and genomic layers.</p>
-          <ul class="tag-row"><li class="tag">Proteomics</li></ul>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/bioinformatics.html" target="_blank" rel="noopener">Bioinformatics Data</a></h3>
-          <p>General-purpose bioinformatics datasets and tooling references.</p>
-          <ul class="tag-row"><li class="tag">Bioinformatics</li></ul>
-        </article>
+      <div data-resources="datasets">
+        <noscript>
+          <ul>
+            <li><a href="https://odin.mdacc.tmc.edu/~wwang7/data_resources.html">Genomics Data</a></li>
+            <li><a href="https://statsupai.org/pages/neuroimaging2.html">Medical Imaging Data</a></li>
+            <li><a href="https://statsupai.org/pages/micro2.html">Microbiome &amp; Metagenomics</a></li>
+            <li><a href="https://statsupai.org/pages/data_ehr.html">EHR Data</a></li>
+            <li><a href="https://statsupai.org/pages/clinicaltrial.html">Clinical Trial Data</a></li>
+            <li><a href="https://statsupai.org/pages/biobank_dataset.html">Biobank Data</a></li>
+            <li><a href="https://statsupai.org/pages/Omics_data.html">Spatial Transcriptomics</a></li>
+            <li><a href="https://statsupai.org/pages/Proteogenomics.html">Proteomics Data</a></li>
+            <li><a href="https://statsupai.org/pages/bioinformatics.html">Bioinformatics Data</a></li>
+          </ul>
+        </noscript>
       </div>
     </div>
   </section>
@@ -106,6 +79,8 @@
   </div>
 </footer>
 
+<script src="assets/js/render.js" defer></script>
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/events.html
+++ b/statsupai-revamp/events.html
@@ -7,6 +7,11 @@
   <meta name="description" content="StatsUpAI webinar series: Health Data Science, and Generative AI & Statistics — talks bridging statistical methodology and modern AI.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/events/webinars/">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -53,23 +58,15 @@
         </article>
       </div>
 
-      <div class="section-head"><div class="kicker">2026 schedule</div><h2>Recent &amp; upcoming talks</h2></div>
-      <div class="timeline">
-        <div class="event">
-          <span class="date">Jan 9, 2026</span><span class="badge">Health</span>
-          <h3>Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine</h3>
-          <p class="meta">Andrew Saykin · Indiana University School of Medicine</p>
-        </div>
-        <div class="event">
-          <span class="date">Jan 16, 2026</span><span class="badge">GenAI</span>
-          <h3>Leveraging LLMs for student feedback in introductory data science courses</h3>
-          <p class="meta">Mine Çetinkaya-Rundel · Duke University</p>
-        </div>
-        <div class="event">
-          <span class="date">Feb 11, 2026</span><span class="badge">GenAI</span>
-          <h3>AI agents to accelerate scientific discoveries</h3>
-          <p class="meta">James Zou · Stanford University</p>
-        </div>
+      <div id="events-root">
+        <noscript>
+          <div class="section-head"><div class="kicker">2026 schedule</div><h2>Talks</h2></div>
+          <ul>
+            <li>Jan 9, 2026 — Andrew Saykin (Indiana University): Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine [Health]</li>
+            <li>Jan 16, 2026 — Mine Çetinkaya-Rundel (Duke University): Leveraging LLMs for student feedback in introductory data science courses [GenAI]</li>
+            <li>Feb 11, 2026 — James Zou (Stanford University): AI agents to accelerate scientific discoveries [GenAI]</li>
+          </ul>
+        </noscript>
       </div>
       <p style="margin-top:28px">
         <a class="btn btn-primary" href="https://statsupai.org/events/webinars/" target="_blank" rel="noopener">Full schedule &amp; registration</a>
@@ -93,6 +90,8 @@
   </div>
 </footer>
 
+<script src="assets/js/render.js" defer></script>
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/index.html
+++ b/statsupai-revamp/index.html
@@ -12,6 +12,23 @@
   <meta property="og:description" content="A community empowering statisticians to lead in AI research.">
   <meta property="og:url" content="https://statsupai.org/">
   <link rel="preload" href="assets/css/main.css" as="style">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "StatsUpAI",
+    "alternateName": "Stats Up AI",
+    "url": "https://statsupai.org",
+    "description": "An ASA interest group empowering statisticians to lead in AI research through curated datasets, review articles, ready-to-use pipelines, community news and a webinar series.",
+    "memberOf": { "@type": "Organization", "name": "American Statistical Association", "url": "https://www.amstat.org" },
+    "sameAs": ["https://groups.google.com/g/stats-up-ai/"]
+  }
+  </script>
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -180,6 +197,7 @@
   </div>
 </footer>
 
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/pipeline.html
+++ b/statsupai-revamp/pipeline.html
@@ -7,6 +7,11 @@
   <meta name="description" content="Expert-curated, ready-to-use analysis pipelines for EHR, neuroimaging, data fusion and clinical-trial data processing.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/pipeline.html">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -40,31 +45,15 @@
 
   <section class="block">
     <div class="container">
-      <div class="grid cols-2">
-        <article class="card">
-          <h3><a href="https://github.com/data-processing-pipeline/EHR_data_pipelines/tree/main" target="_blank" rel="noopener">EHR Data Pipelines</a></h3>
-          <p>A collection of pipelines for processing Electronic Health Record data,
-          from ingestion through analysis-ready datasets.</p>
-          <a class="more" href="https://github.com/data-processing-pipeline/EHR_data_pipelines/tree/main" target="_blank" rel="noopener">Open on GitHub</a>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Neuroimaging%20Processing%20Software.html" target="_blank" rel="noopener">Neuroimaging Processing Software</a></h3>
-          <p>Key neuroimaging tools widely used in neuroscience research, with their
-          corresponding academic publications.</p>
-          <a class="more" href="https://statsupai.org/pages/Neuroimaging%20Processing%20Software.html" target="_blank" rel="noopener">View tools</a>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/Data_Fusion_Analysis_Pipeline_pipeline.html" target="_blank" rel="noopener">Data Fusion Analysis Pipeline</a></h3>
-          <p>A modular framework that integrates diverse data sources and analytical models
-          to improve predictive accuracy and decision-making.</p>
-          <a class="more" href="https://statsupai.org/pages/Data_Fusion_Analysis_Pipeline_pipeline.html" target="_blank" rel="noopener">Learn more</a>
-        </article>
-        <article class="card">
-          <h3><a href="https://statsupai.org/pages/clinicaltrials_pipeline.html" target="_blank" rel="noopener">Clinical Trials Data Processing</a></h3>
-          <p>Efficient pipelines for processing and analyzing clinical-trial data to
-          streamline research workflows.</p>
-          <a class="more" href="https://statsupai.org/pages/clinicaltrials_pipeline.html" target="_blank" rel="noopener">Learn more</a>
-        </article>
+      <div data-resources="pipelines">
+        <noscript>
+          <ul>
+            <li><a href="https://github.com/data-processing-pipeline/EHR_data_pipelines/tree/main">EHR Data Pipelines</a></li>
+            <li><a href="https://statsupai.org/pages/Neuroimaging%20Processing%20Software.html">Neuroimaging Processing Software</a></li>
+            <li><a href="https://statsupai.org/pages/Data_Fusion_Analysis_Pipeline_pipeline.html">Data Fusion Analysis Pipeline</a></li>
+            <li><a href="https://statsupai.org/pages/clinicaltrials_pipeline.html">Clinical Trials Data Processing</a></li>
+          </ul>
+        </noscript>
       </div>
     </div>
   </section>
@@ -85,6 +74,8 @@
   </div>
 </footer>
 
+<script src="assets/js/render.js" defer></script>
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/statsupai-revamp/robots.txt
+++ b/statsupai-revamp/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://statsupai.org/sitemap.xml

--- a/statsupai-revamp/scripts/check.mjs
+++ b/statsupai-revamp/scripts/check.mjs
@@ -1,0 +1,65 @@
+/* Zero-dependency site checks. Run: node statsupai-revamp/scripts/check.mjs
+   Gates: JSON validity, internal link integrity, asset-weight budget,
+   per-page HTML sanity. Exits non-zero on any failure. */
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+
+const ROOT = resolve(new URL("..", import.meta.url).pathname);
+// 900 KB ceiling catches the original site's catastrophic 9–12 MB class.
+// Tighten to ~120 KB once headshots are re-encoded to WebP (see MAINTAINING.md).
+const MAX_ASSET = 900 * 1024;
+const MAX_IMG_DIR = 8 * 1024 * 1024;   // 8 MB total under assets/img
+const errors = [];
+const ok = (m) => console.log("  ok  " + m);
+const fail = (m) => { errors.push(m); console.log("FAIL  " + m); };
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((n) => {
+    const p = join(dir, n);
+    return statSync(p).isDirectory() ? walk(p) : [p];
+  });
+}
+
+// 1. JSON validity
+console.log("\n• JSON");
+for (const f of walk(join(ROOT, "assets/data"))) {
+  if (!f.endsWith(".json")) continue;
+  try { JSON.parse(readFileSync(f, "utf8")); ok(f.replace(ROOT + "/", "")); }
+  catch (e) { fail(`${f}: ${e.message}`); }
+}
+
+// 2. HTML sanity + internal links
+console.log("\n• HTML pages");
+const htmls = readdirSync(ROOT).filter((f) => f.endsWith(".html"));
+for (const f of htmls) {
+  const s = readFileSync(join(ROOT, f), "utf8");
+  const h1 = (s.match(/<h1[ >]/g) || []).length;
+  if (f !== "404.html" && h1 !== 1) fail(`${f}: expected exactly one <h1>, found ${h1}`);
+  if (!/<html lang="en">/.test(s)) fail(`${f}: missing <html lang="en">`);
+  if (!/<title>/.test(s)) fail(`${f}: missing <title>`);
+  if (!/assets\/css\/main\.css/.test(s)) fail(`${f}: missing main.css`);
+  if (f !== "404.html" && !/rel="canonical"/.test(s)) fail(`${f}: missing canonical`);
+
+  for (const m of s.matchAll(/(?:href|src)="([^"#][^"]*)"/g)) {
+    const u = m[1];
+    if (/^(https?:|mailto:|tel:|data:|\/\/)/.test(u)) continue;
+    const target = u.split(/[?#]/)[0];
+    if (!target) continue;
+    if (!existsSync(join(ROOT, target))) fail(`${f}: dead internal link → ${u}`);
+  }
+  ok(f);
+}
+
+// 3. Asset-weight budget
+console.log("\n• Asset budget");
+let imgTotal = 0;
+for (const f of walk(join(ROOT, "assets"))) {
+  const sz = statSync(f).size;
+  if (f.includes("/assets/img/")) imgTotal += sz;
+  if (sz > MAX_ASSET) fail(`${f.replace(ROOT + "/", "")} is ${(sz/1024|0)} KB (> ${MAX_ASSET/1024} KB budget)`);
+}
+if (imgTotal > MAX_IMG_DIR) fail(`assets/img total ${(imgTotal/1024/1024).toFixed(1)} MB (> ${MAX_IMG_DIR/1024/1024} MB)`);
+else ok(`assets/img total ${(imgTotal/1024/1024).toFixed(1)} MB`);
+
+console.log(`\n${errors.length ? "✗ " + errors.length + " problem(s)" : "✓ all checks passed"}`);
+process.exit(errors.length ? 1 : 0);

--- a/statsupai-revamp/site.webmanifest
+++ b/statsupai-revamp/site.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "StatsUpAI",
+  "short_name": "StatsUpAI",
+  "description": "Statistics shaping the future of Artificial Intelligence — an ASA interest group.",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0c1413",
+  "theme_color": "#088080",
+  "icons": [
+    { "src": "assets/img/favicon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/statsupai-revamp/sitemap.xml
+++ b/statsupai-revamp/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Production URLs (statsupai.org). When deployed to the domain root this is /sitemap.xml. -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://statsupai.org/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://statsupai.org/datasets.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://statsupai.org/articles.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://statsupai.org/pipeline.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://statsupai.org/community-news.html</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://statsupai.org/team.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://statsupai.org/events/webinars/</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+</urlset>

--- a/statsupai-revamp/team.html
+++ b/statsupai-revamp/team.html
@@ -7,6 +7,11 @@
   <meta name="description" content="The StatsUpAI steering committee and technical team — statisticians and data scientists across leading universities and research centers.">
   <meta name="theme-color" content="#088080">
   <link rel="canonical" href="https://statsupai.org/team.html">
+  <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="assets/img/favicon.svg">
+  <link rel="manifest" href="site.webmanifest">
+  <meta property="og:image" content="https://statsupai.org/assets/img/og.svg">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
@@ -67,6 +72,7 @@
 </footer>
 
 <script src="assets/js/team-data.js" defer></script>
+<script src="assets/js/analytics.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Deeper operability pass on `/statsupai-revamp/` — making the revamp behave like
a real high-end site for a mass academic group, from infra/tooling up to
real-life usage and automation. Follows the merged #2.

## What changed

**Data-driven content (one-file edits for non-engineers)**
- `assets/data/events.json` — webinars; page auto-splits Upcoming/Past by date,
  generates `.ics` "Add to calendar", flips to "Watch recording" when set.
- `assets/data/resources.json` — datasets/articles/pipelines rendered with a
  client-side search box + topic filter chips.
- `<noscript>` link lists keep every data-driven page crawlable / no-JS usable.

**SEO / discoverability**
- JSON-LD: `Organization` (home), `Event` + `ItemList` (rendered) → eligible
  for Google event rich results.
- `sitemap.xml`, `robots.txt`, `404.html`, web manifest, SVG favicon + OG image.

**Automation / code management**
- `scripts/check.mjs` (zero-dep): JSON validity, internal-link integrity,
  per-page HTML sanity, **asset-weight budget** (the guardrail against the
  original 9–12 MB image class).
- `.github/workflows/statsupai-revamp.yml` — path-scoped to `statsupai-revamp/**`
  so it never runs on unrelated daily dashboard commits; runs the checks +
  htmlhint.
- `analytics.js` — opt-in, prod-host-only, honors DNT, `anonymize_ip`.

**Docs**
- `MAINTAINING.md` for non-technical maintainers.
- `AUDIT.md` extended with the round-2 (infra → operations → automation) findings.

## Verification

- `node statsupai-revamp/scripts/check.mjs` → all checks pass locally.
- All four JS files pass `node --check`.

## Known limitations

- Headshots are still the original unoptimized files (no image tooling in this
  environment); budget is set at 900 KB and should be tightened after WebP
  re-encode.
- `robots.txt`/`sitemap.xml`/`404.html` only activate at a domain root.
- Content/team data should be re-synced from canonical
  `Statsup-AI/statsupai.github.io` (outside this env's repo scope).

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_