### PR TITLE
events: back-fill full StatsUpAI webinar history

### DIFF
--- a/statsupai-revamp/assets/data/events.json
+++ b/statsupai-revamp/assets/data/events.json
@@ -1,10 +1,43 @@
 {
-  "_comment": "SINGLE SOURCE OF TRUTH for webinars. Non-technical maintainers: add an object, commit. CI validates it; the site auto-sorts upcoming vs past by date and builds calendar links. Date = ISO YYYY-MM-DD. time_et like '12:00 PM'. series = 'Health' | 'GenAI'.",
+  "_comment": "SINGLE SOURCE OF TRUTH for webinars. Non-technical maintainers: add an object to talks, commit. CI validates it; the site auto-sorts upcoming vs past by date and builds calendar links. date = ISO YYYY-MM-DD. time_et like '12:00 PM'. series = 'Health' | 'GenAI'. Compiled from the stats-up-ai@googlegroups.com announcements.",
   "series": {
-    "Health": { "label": "Health Data Science Series", "tagline": "Big-data & AI methods for health, imaging, genetics and clinical phenotyping." },
+    "Health": { "label": "Health Data Science Series", "tagline": "Statistical and AI methods for health data science — neuroimaging, genomics, EHR, microbiome and more." },
     "GenAI": { "label": "GenAI × Statistics Series", "tagline": "Bridging the gap between generative AI and statistical methodologies." }
   },
   "talks": [
+    {
+      "date": "2025-04-09",
+      "time_et": "12:00 PM",
+      "duration_min": 60,
+      "speaker": "Martin Lindquist",
+      "affiliation": "Johns Hopkins University",
+      "title": "Elements of Functional Neuroimaging",
+      "series": "Health",
+      "registration_link": "https://upenn.zoom.us/j/94227327976",
+      "recording_link": ""
+    },
+    {
+      "date": "2025-05-08",
+      "time_et": "3:00 PM",
+      "duration_min": 60,
+      "speaker": "Ying Guo",
+      "affiliation": "Emory University",
+      "title": "Exploring Brain Function and Connectivity with fMRI: From Data Characteristics to Statistical and AI Methods",
+      "series": "Health",
+      "registration_link": "https://upenn.zoom.us/j/99182616852",
+      "recording_link": ""
+    },
+    {
+      "date": "2025-12-02",
+      "time_et": "1:00 PM",
+      "duration_min": 60,
+      "speaker": "Ani Eloyan",
+      "affiliation": "Brown University",
+      "title": "Manifold Learning for Modeling Shapes in Alzheimer's Disease",
+      "series": "Health",
+      "registration_link": "https://upenn.zoom.us/meeting/register/SL8s_eubT-6qoVoMJRsK6w",
+      "recording_link": "https://www.youtube.com/@StatsUpAI/videos"
+    },
     {
       "date": "2026-01-09",
       "time_et": "12:00 PM",
@@ -13,7 +46,7 @@
       "affiliation": "Indiana University School of Medicine",
       "title": "Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine",
       "series": "Health",
-      "registration_link": "https://upenn.zoom.us/meeting/register/uA1Jh_J8T3Wez4q0rbpTLQ#/registration",
+      "registration_link": "https://upenn.zoom.us/meeting/register/uA1Jh_J8T3Wez4q0rbpTLQ",
       "recording_link": ""
     },
     {
@@ -36,6 +69,28 @@
       "title": "AI agents to accelerate scientific discoveries",
       "series": "GenAI",
       "registration_link": "https://sfu.zoom.us/meeting/register/3MLcnkc9TJCYfHNrdVSbeQ#/registration",
+      "recording_link": ""
+    },
+    {
+      "date": "2026-05-08",
+      "time_et": "2:00 PM",
+      "duration_min": 60,
+      "speaker": "Curtis Huttenhower",
+      "affiliation": "Harvard T.H. Chan School of Public Health",
+      "title": "Quantitative methods for microbial communities and the human microbiome",
+      "series": "Health",
+      "registration_link": "https://us02web.zoom.us/meeting/register/6V5L7h7YQ0-qs6JqnElBfg",
+      "recording_link": ""
+    },
+    {
+      "date": "2026-05-26",
+      "time_et": "2:00 PM",
+      "duration_min": 60,
+      "speaker": "Naim Rashid",
+      "affiliation": "University of North Carolina–Chapel Hill",
+      "title": "Staying in the Driver's Seat: Calibrating AI Use in Statistical Research, Training, and Practice",
+      "series": "GenAI",
+      "registration_link": "https://sfu.zoom.us/meeting/register/t_dkc6edSq2ql2STmKquqw",
       "recording_link": ""
     }
   ]

--- a/statsupai-revamp/events.html
+++ b/statsupai-revamp/events.html
@@ -60,11 +60,16 @@
 
       <div id="events-root">
         <noscript>
-          <div class="section-head"><div class="kicker">2026 schedule</div><h2>Talks</h2></div>
+          <div class="section-head"><div class="kicker">Schedule</div><h2>Talks</h2></div>
           <ul>
-            <li>Jan 9, 2026 — Andrew Saykin (Indiana University): Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine [Health]</li>
+            <li>Apr 9, 2025 — Martin Lindquist (Johns Hopkins University): Elements of Functional Neuroimaging [Health]</li>
+            <li>May 8, 2025 — Ying Guo (Emory University): Exploring Brain Function and Connectivity with fMRI [Health]</li>
+            <li>Dec 2, 2025 — Ani Eloyan (Brown University): Manifold Learning for Modeling Shapes in Alzheimer's Disease [Health]</li>
+            <li>Jan 9, 2026 — Andrew Saykin (Indiana University School of Medicine): Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine [Health]</li>
             <li>Jan 16, 2026 — Mine Çetinkaya-Rundel (Duke University): Leveraging LLMs for student feedback in introductory data science courses [GenAI]</li>
             <li>Feb 11, 2026 — James Zou (Stanford University): AI agents to accelerate scientific discoveries [GenAI]</li>
+            <li>May 8, 2026 — Curtis Huttenhower (Harvard T.H. Chan School of Public Health): Quantitative methods for microbial communities and the human microbiome [Health]</li>
+            <li>May 26, 2026 — Naim Rashid (UNC–Chapel Hill): Staying in the Driver's Seat: Calibrating AI Use in Statistical Research, Training, and Practice [GenAI]</li>
           </ul>
         </noscript>
       </div>


### PR DESCRIPTION
Backfills the revamp events page with the **complete StatsUpAI webinar
history**, compiled from the `stats-up-ai@googlegroups.com` announcement
emails (the canonical source for these talks).

`assets/data/events.json` + the `events.html` no-JS fallback now carry all
8 talks across both series. The page auto-splits upcoming vs. past by
today's date and generates `.ics` calendar links — no manual edits needed
as talks move into the past.

### Health Data Science Series
| Date | Speaker | Affiliation | Talk |
|---|---|---|---|
| 2025-04-09 | Martin Lindquist | Johns Hopkins | Elements of Functional Neuroimaging |
| 2025-05-08 | Ying Guo | Emory | Exploring Brain Function and Connectivity with fMRI |
| 2025-12-02 | Ani Eloyan | Brown | Manifold Learning for Modeling Shapes in Alzheimer's Disease |
| 2026-01-09 | Andrew Saykin | Indiana U. School of Medicine | Deconstructing Alzheimer's Disease and Related Dementias |
| 2026-05-08 | Curtis Huttenhower | Harvard Chan | Quantitative methods for microbial communities and the human microbiome |

### GenAI × Statistics Series
| Date | Speaker | Affiliation | Talk |
|---|---|---|---|
| 2026-01-16 | Mine Çetinkaya-Rundel | Duke | Leveraging LLMs for student feedback in intro data science courses |
| 2026-02-11 | James Zou | Stanford | AI agents to accelerate scientific discoveries |
| 2026-05-26 | Naim Rashid | UNC–Chapel Hill | Staying in the Driver's Seat: Calibrating AI Use in Statistical Research |

### Notes / assumptions to confirm
- Registration links are the per-talk Zoom links from each announcement;
  older ones (Lindquist/Guo) were direct `zoom.us/j/...` join links.
- Recordings: only a generic channel link exists
  (youtube.com/@StatsUpAI). Per-talk recording URLs left blank → page shows
  "Recording TBA". Drop them into `recording_link` when available.
- James Zou entry retained from the prior mirror data (no email found in
  this mailbox); please sanity-check date/registration.
- Implementation/infra audit tracked separately in #4.

Checks pass locally (`node statsupai-revamp/scripts/check.mjs`).

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_