### PR TITLE
Revamp site: custom periwinkle–lilac Jekyll theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+Gemfile.lock
+.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,51 @@
+# ── Yulin Li · personal site ───────────────────────────────
+title: Yulin Li
+tagline: Statistics · AI · Music
+description: >-
+  Personal space of Yulin Li — Ph.D. candidate in Statistics at
+  Rutgers, documenting a journey across math, science, and art.
+author: Yulin Li
+url: "https://yulinl2.github.io"
+baseurl: ""
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  hard_wrap: false
+
+# Build hygiene — keep static sub-sites & scratch out of the
+# themed build, but they remain reachable as plain files/links.
+exclude:
+  - "README.md"
+  - "*.code-workspace"
+  - ".vscode"
+  - ".github"
+  - "vendor"
+  - "Gemfile"
+  - "Gemfile.lock"
+  - "toolbox/scratch-papers/GPT"
+
+# Every themed markdown page gets the interior layout by default;
+# the front page opts into the rich home layout explicitly.
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: page
+  - scope:
+      path: "index.md"
+    values:
+      layout: home
+
+# Navigation (rendered in the header + footer)
+nav:
+  - { name: "Research",  url: "/docs/" }
+  - { name: "Library",   url: "/reading/" }
+  - { name: "Projects",  url: "/projects/" }
+  - { name: "Toolbox",   url: "/toolbox/" }
+
+social:
+  github: "yulinl2"
+
+plugins: []

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,29 @@
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <h4>{{ site.title }}</h4>
+        <p class="blurb">{{ site.description }}</p>
+      </div>
+      <div>
+        <h4>Explore</h4>
+        <ul>
+          {% for item in site.nav %}
+            <li><a href="{{ item.url | relative_url }}">{{ item.name }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div>
+        <h4>Elsewhere</h4>
+        <ul>
+          <li><a href="https://github.com/{{ site.social.github }}">GitHub</a></li>
+          <li><a href="{{ '/archive/homepage/20260518-index.md' | relative_url }}">Archive</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span class="sig">© {{ 'now' | date: "%Y" }} Yulin Li</span>
+      <span>Built with care · periwinkle &amp; lilac</span>
+    </div>
+  </div>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,13 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if page.title and page.url != "/" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }} — {{ site.tagline }}{% endif %}</title>
+<meta name="description" content="{{ page.description | default: site.description }}">
+<meta name="author" content="{{ site.author }}">
+<meta name="theme-color" content="#6687ff">
+<meta property="og:title" content="{{ page.title | default: site.title }}">
+<meta property="og:description" content="{{ page.description | default: site.description }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ site.url }}{{ page.url }}">
+<link rel="canonical" href="{{ site.url }}{{ page.url }}">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%236687ff'/%3E%3Cstop offset='1' stop-color='%23a866ff'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='9' fill='url(%23g)'/%3E%3Ctext x='16' y='22' font-family='Georgia,serif' font-size='17' fill='white' text-anchor='middle'%3EY%3C/text%3E%3C/svg%3E">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,18 @@
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="{{ '/' | relative_url }}">
+      <span class="mark">Y</span>
+      <span>Yulin&nbsp;Li</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links" aria-label="Menu">☰</button>
+    <ul class="nav-links" id="nav-links">
+      {% for item in site.nav %}
+        {% assign cur = nil %}
+        {% if page.url contains item.url and item.url != "/" %}{% assign cur = "page" %}{% endif %}
+        <li><a href="{{ item.url | relative_url }}"{% if cur %} aria-current="page"{% endif %}>{{ item.name }}</a></li>
+      {% endfor %}
+      <li><a href="https://github.com/{{ site.social.github }}" rel="me">GitHub</a></li>
+    </ul>
+  </div>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>{% include head.html %}</head>
+<body>
+  {% include header.html %}
+  <main id="main">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+  <script src="{{ '/assets/js/main.js' | relative_url }}" defer></script>
+</body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,97 @@
+---
+layout: default
+---
+<section class="hero">
+  <span class="blob b1"></span>
+  <span class="blob b2"></span>
+  <span class="blob b3"></span>
+  <div class="container hero-inner">
+    <div>
+      <span class="eyebrow">{{ site.tagline }}</span>
+      <h1>Hi, I&rsquo;m <span class="grad">Yulin&nbsp;Li</span>.</h1>
+      <p class="lead">{{ page.intro }}</p>
+      <ul class="fact-row">
+        {% for f in page.facts %}<li class="fact">{{ f }}</li>{% endfor %}
+      </ul>
+      <div class="btn-row">
+        <a class="btn btn-primary" href="#work">See my work</a>
+        <a class="btn btn-ghost" href="https://github.com/{{ site.social.github }}">GitHub</a>
+      </div>
+    </div>
+    <div class="portrait">
+      <img src="{{ '/assets/images/2024-rutgers-profile.png' | relative_url }}"
+           alt="Portrait of Yulin Li" loading="eager" width="320" height="320">
+    </div>
+  </div>
+</section>
+
+<section class="block" id="work">
+  <div class="container">
+    <div class="section-head">
+      <p class="kicker">What I&rsquo;m building</p>
+      <h2>Research, notes &amp; experiments</h2>
+      <p>A working record of the ideas I&rsquo;m chasing at the intersection of statistics, machine learning, and art.</p>
+    </div>
+    <div class="grid cols-3">
+      {% for c in page.cards %}
+      <article class="card" data-reveal="{{ forloop.index0 }}">
+        <div class="ico">{{ c.icon }}</div>
+        <h3><a href="{{ c.url | relative_url }}">{{ c.title }}</a></h3>
+        <p>{{ c.body }}</p>
+        {% if c.tags %}<ul class="tag-row">{% for t in c.tags %}<li class="tag">{{ t }}</li>{% endfor %}</ul>{% endif %}
+        <a class="more" href="{{ c.url | relative_url }}">{{ c.cta | default: "Explore" }}</a>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="block soft">
+  <div class="container">
+    <div class="section-head">
+      <p class="kicker">Teaching journey</p>
+      <h2>In the classroom &amp; recitation room</h2>
+      <p>Statistics and mathematics, from PhD seminars to first-year calculus &mdash; across Rutgers, Boston University, and Zhejiang University.</p>
+    </div>
+    <div class="timeline">
+      {% for t in page.teaching %}
+      <div class="tl-item" data-reveal="{{ forloop.index0 }}">
+        <div class="date">{{ t.when }}</div>
+        <h3>{{ t.course }}</h3>
+        <p class="meta">{{ t.detail }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="block">
+  <div class="container">
+    <div class="section-head">
+      <p class="kicker">Off the page</p>
+      <h2>A life in music</h2>
+      <p>Conductor, music director, arranger, and accompanist &mdash; building choirs and concerts wherever I go.</p>
+    </div>
+    <div class="timeline">
+      {% for m in page.music %}
+      <div class="tl-item" data-reveal="{{ forloop.index0 }}">
+        <div class="date">{{ m.when }}</div>
+        <h3>{{ m.title }}</h3>
+        <p class="meta">{{ m.detail }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+<section class="block soft">
+  <div class="container narrow">
+    <div class="section-head">
+      <p class="kicker">Colophon</p>
+      <h2>About this site</h2>
+    </div>
+    <div class="prose">
+      {{ content }}
+    </div>
+  </div>
+</section>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,17 @@
+---
+layout: default
+---
+<section class="hero">
+  <span class="blob b2"></span>
+  <div class="container page-head">
+    <p class="crumb"><a href="{{ '/' | relative_url }}">Home</a> &nbsp;/&nbsp; {{ page.title | default: "Page" }}</p>
+    <h1>{{ page.title | default: "Untitled" }}</h1>
+    {% if page.description %}<p class="lead">{{ page.description }}</p>{% endif %}
+  </div>
+</section>
+
+<div class="container">
+  <article class="prose narrow">
+    {{ content }}
+  </article>
+</div>

--- a/archive/homepage/20260518-index.md
+++ b/archive/homepage/20260518-index.md
@@ -1,0 +1,178 @@
+---
+title: Home
+layout: default
+---
+
+# Home
+
+This is Yulin's personal space to document her journeys in **math**, **science**, and **art**.
+
+
+
+
+> ***Here I am in**: Jan 2025*
+>
+> <img src="./assets/images/2024-rutgers-profile.png" alt="Yulin: Sep 2023" style="max-width: 18rem; width: 30%"/>
+> Ph.D. Candidate  
+> 
+> **Department of Statistics, Rutgers--New Brunswick**
+> 
+
+## Resources
+
+### [Academics](./docs/academic/index.md)
+- **Tutorials**: Learning from sharing.  
+  - [A Beginner's Guide to GitHub](./docs/tutorials/HTML_GitHub_Tutorial.html) (v1.5: 01/2025, v1.0: 02/2022)
+- **Communities**
+  - [**StatsUp AI** (https://statsupai.org)](https://statsupai.org): A frontier information platform for statisticians in AI research and revolution.
+  - [**Lunch Salon**](https://mp.weixin.qq.com/s/yIelqWgUyHuEE4iSJwFYGw): A student-organized media for scientific knowledge sharing.
+    
+    - [ ] `TO-DO: include article links`
+    
+    > **Bio**:
+    > Joint work by 7 of the [ZH1Z](https://en.wikipedia.org/wiki/Zhuhai_No.1_High_School) 2017 graduates.
+    >
+    > **Articles**: `Psychology`x4, `Biochemistry`x3, `Computer Science & Engineering`x3, `Motorsports Technology`x2, `Linguistics`x2, `Architecture`x1, `Math History`x1, `Music`x1
+    >
+    > Last update: 02/04/2019
+    ><div style="padding-left: 3rem">
+    >  <img src="./assets/images/2017-lunch-salon.jpeg" alt="Lunch Salon: 2017"  style="max-height: 10rem" />
+    ></div>
+    >
+    
+- **[My Reference Library](./reading/index.md)**: Reference organizer and reading roadmap.
+
+- **My Favorites in Statistics**: Domain highlights and key insights.
+
+
+### Musical Works
+`Under construction...`
+
+- Performance Videos  
+- Music Scores 
+  - Transcriptions
+  - Compositions
+- Activity Timeline
+
+
+## My Teaching Journey
+### Math & Statistics
+#### PhD-level courses
+  - **STAT 596: Advanced Applied Statistics I** Fall 2024
+      
+      Teaching Assistant, Department of Statistics, Rutgers University
+
+  - **MA 751: Statistical Machine Learning** (Section A2, A3) Spring 2023
+      
+      Teaching Assistant, Department of Math & Statistics, Boston University
+
+      Recitations: 2 hr/wk; Total Class Size: 20
+
+#### Graduate-level courses
+  - **MA 575: Linear Models** (Section B1, B2, B3, B4, B5) Spring 2022
+      
+      Teaching Assistant, Department of Math & Statistics, Boston University
+      
+      Recitations: 5 hr/wk; Total Class Size: 80
+#### Undergraduate-level courses
+  - **MATH 241: Calculus III** (Section ?, ?) Fall 2020
+      
+      Teaching Assistant, ZJU-UIUC Institute, Zhejiang University
+      
+      Recitations: 4 hr/wk; Total Class Size: 40
+  - **MATH 241: Calculus III** (Section ?, ?) Fall 2019
+      
+      Teaching Assistant, ZJU-UIUC Institute, Zhejiang University
+      
+      Recitations: 4 hr/wk; Total Class Size: 40
+        
+### Music
+
+  - **1st Chamber Concert of International Campus, ZJU** Fall 2020
+    
+    Director, Musical Director, Piano Accompanist
+
+    > 
+    > **Event Schedule**: Sunday Dec 6, 2020 `18:30-21:00`
+    > 
+    > *Event Highlights:* **[*Intl-ZJU News*](https://mp.weixin.qq.com/s/4tOWEFEcM4L6ZsTlfMB37w)**
+    > 
+    > **Concert Programme**: 
+    ><div style="padding-left: 3rem">
+    >  <img src="./assets/images/2020-concert-programme-1.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
+    >  <img src="./assets/images/2020-concert-programme-2.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
+    >  <img src="./assets/images/2020-concert-programme-3.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
+    ></div>
+  
+  - **Student Choir of International Campus, ZJU** 2017-2020
+    
+    Musical Director, Conductor, Piano Accompanist
+    
+    > ***Team members***: ~30 students from all schools, years, ages, and nationalities at the *International Campus of Zhejiang University*.
+    > 
+    > ***Performed***: 
+    > * ***Can't Help Falling in Love*** (A cappella) Dec 2020
+    > * ***菊花台*** (SATB) Dec 2019 
+    > * ***Seasons of Love*** (SATB) Dec 2019
+    ><div style="padding-left: 3rem">
+    >  <img src="./assets/images/2019-choir-on-stage.jpeg" alt="Choir: 2019"  style="max-height: 100%" />
+    >  <img src="./assets/images/2019-choir.jpeg" alt="Choir: 2019"  style="max-height: 150px" />
+    ></div>
+    > 
+
+  - **2019 Freshmen Choral Competition of Zhejiang University** Aug 2019
+    
+    Music Arranger, Instrument & Vocal Coach
+    
+    - Team Size: 100+ (representing ZJU-UoE Institute)
+    - Total Participants: 4000+
+    - Performed: 
+      - ***University Anthem***（SATB), arr. Yulin Li (2019)
+      - ***汪峰：我爱你中国***（SATB)
+    - Placement: ***2nd-Place** Finalist*
+
+  - **2018 Freshmen Choral Competition of Zhejiang University** Aug 2018
+    
+    Music Arranger, Instrument & Vocal Coach
+    
+    - Team Size: 80+ (representing ZJU-UoE Institute)
+    - Total Participants: 4000+
+    - Performed: 
+      - ***University Anthem***（SATB), arr. Yulin Li (2018)
+      - ***少年中国说***（SATB), arr. Yulin Li (2018)
+
+  - **2017 Freshmen Choral Competition of Zhejiang University** Aug 2017
+    
+    Music Arranger, Instrument & Vocal Coach, Conductor
+    
+    - Team Size: 180+ (representing ZJU-UIUC Institute)
+    - Total Participants: 4000+
+    - Performed: 
+      - ***University Anthem***（SATB), arr. Xinhai Zhu (2017)
+      - ***生来倔强***（SATB), arr. Yulin Li (2017)
+    - Placement: ***2nd-Place** Finalist*
+
+
+
+
+
+## My Toolboxes
+
+`Under construction...`
+
+### [Projects](./projects/index.md)
+- **Ongoing Projects**  
+
+
+
+### Toolboxes
+- **[Toolbox](./toolbox/index.md)**  
+
+
+
+## About This Site
+
+`Under construction...`
+
+*Last updated: 01-12-2025*
+

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,330 @@
+/* ────────────────────────────────────────────────────────────
+   Yulin Li — personal site design system
+   Dependency-free · system fonts · light/dark aware
+   Palette: Periwinkle–Lilac Staircase (蓝紫云梯)
+   ──────────────────────────────────────────────────────────── */
+
+:root {
+  /* core palette */
+  --peri-600: #4f6bff;
+  --peri-500: #6687ff;
+  --peri-300: #adbfff;
+  --peri-200: #d1dbff;
+  --lilac-200: #e5d1ff;
+  --lilac-300: #d1adff;
+  --grape-500: #a866ff;
+  --grape-700: #7d3fe0;
+
+  /* semantic — light */
+  --ink: #21244a;
+  --body: #4b4f78;
+  --muted: #7d80ad;
+  --line: rgba(102, 135, 255, .20);
+  --bg: #f6f6ff;
+  --bg-soft: #eceeff;
+  --card: rgba(255, 255, 255, .72);
+  --card-solid: #ffffff;
+  --accent: var(--peri-600);
+  --accent-2: var(--grape-500);
+  --accent-ink: #ffffff;
+  --chip-bg: rgba(102, 135, 255, .10);
+
+  --grad: linear-gradient(135deg, var(--peri-500) 0%, var(--grape-500) 100%);
+  --grad-soft: linear-gradient(135deg, var(--peri-200), var(--lilac-200));
+
+  --radius: 18px;
+  --radius-sm: 12px;
+  --shadow: 0 2px 6px rgba(79, 107, 255, .07), 0 18px 48px -20px rgba(125, 63, 224, .28);
+  --shadow-lg: 0 10px 40px -12px rgba(102, 135, 255, .35);
+  --maxw: 1140px;
+
+  --font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, ui-serif, serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #ecedff;
+    --body: #c4c7ef;
+    --muted: #9094c6;
+    --line: rgba(173, 191, 255, .16);
+    --bg: #0d0f2b;
+    --bg-soft: #14173a;
+    --card: rgba(40, 44, 88, .50);
+    --card-solid: #181b3d;
+    --accent: #94a9ff;
+    --accent-2: #c9adff;
+    --accent-ink: #14163a;
+    --chip-bg: rgba(148, 169, 255, .12);
+    --shadow: 0 2px 6px rgba(0, 0, 0, .35), 0 22px 56px -22px rgba(0, 0, 0, .65);
+    --shadow-lg: 0 12px 44px -10px rgba(125, 63, 224, .45);
+    --grad-soft: linear-gradient(135deg, rgba(102, 135, 255, .22), rgba(168, 102, 255, .22));
+  }
+}
+
+* { box-sizing: border-box; margin: 0; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+
+body {
+  font-family: var(--font);
+  color: var(--body);
+  background: var(--bg);
+  line-height: 1.68;
+  font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+}
+
+h1, h2, h3, h4 { color: var(--ink); line-height: 1.16; font-weight: 700; letter-spacing: -.02em; }
+h1 { font-family: var(--serif); font-weight: 600; font-size: clamp(2.3rem, 5.4vw, 3.7rem); letter-spacing: -.015em; }
+h2 { font-size: clamp(1.55rem, 3.2vw, 2.25rem); margin-bottom: .5em; }
+h3 { font-size: 1.18rem; }
+p { margin-bottom: 1em; }
+
+a { color: var(--accent); text-decoration: none; transition: color .15s ease; }
+a:hover { color: var(--accent-2); }
+img { max-width: 100%; display: block; }
+::selection { background: rgba(168, 102, 255, .25); }
+
+.container { width: 100%; max-width: var(--maxw); margin-inline: auto; padding-inline: 24px; }
+.narrow { max-width: 760px; }
+
+.skip-link {
+  position: absolute; left: 12px; top: -52px; z-index: 200;
+  background: var(--accent); color: var(--accent-ink);
+  padding: 10px 16px; border-radius: 10px; transition: top .15s ease;
+}
+.skip-link:focus { top: 12px; }
+:focus-visible { outline: 3px solid var(--grape-500); outline-offset: 3px; border-radius: 5px; }
+
+/* ── Header / nav ───────────────────────────────────────────── */
+.site-header {
+  position: sticky; top: 0; z-index: 100;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: saturate(180%) blur(14px);
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid var(--line);
+}
+.nav { display: flex; align-items: center; justify-content: space-between; height: 70px; gap: 16px; }
+.brand { display: flex; align-items: center; gap: 11px; font-weight: 700; font-size: 1.12rem; color: var(--ink); letter-spacing: -.02em; }
+.brand:hover { color: var(--ink); }
+.brand .mark {
+  width: 34px; height: 34px; border-radius: 11px; background: var(--grad);
+  display: grid; place-items: center; color: #fff; font-weight: 700;
+  font-family: var(--serif); font-size: 1rem; box-shadow: var(--shadow-lg);
+}
+.nav-links { display: flex; align-items: center; gap: 4px; list-style: none; }
+.nav-links a {
+  display: block; padding: 9px 15px; border-radius: 10px;
+  color: var(--body); font-weight: 500; font-size: .96rem;
+}
+.nav-links a:hover { background: var(--chip-bg); color: var(--ink); }
+.nav-links a[aria-current="page"] { color: var(--accent); background: var(--chip-bg); }
+.nav-toggle {
+  display: none; background: none; border: 1px solid var(--line);
+  color: var(--ink); border-radius: 10px; padding: 9px 12px; cursor: pointer; font-size: 1.05rem;
+}
+@media (max-width: 820px) {
+  .nav-toggle { display: inline-flex; }
+  .nav-links {
+    position: absolute; inset: 70px 0 auto 0; flex-direction: column; align-items: stretch;
+    background: var(--bg); border-bottom: 1px solid var(--line);
+    padding: 12px 18px 20px; gap: 2px; display: none;
+  }
+  .nav-links.open { display: flex; }
+  .nav-links a { padding: 13px 14px; }
+}
+
+/* ── Hero ───────────────────────────────────────────────────── */
+.hero { position: relative; overflow: hidden; isolation: isolate; }
+.hero::before {
+  content: ""; position: absolute; inset: 0; z-index: -2;
+  background:
+    radial-gradient(900px 520px at 82% -8%, rgba(168, 102, 255, .30), transparent 60%),
+    radial-gradient(820px 480px at 6% 4%, rgba(102, 135, 255, .26), transparent 58%),
+    var(--bg);
+}
+.hero::after {
+  content: ""; position: absolute; inset: 0; z-index: -1; pointer-events: none;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 52px 52px;
+  -webkit-mask-image: radial-gradient(700px 460px at 72% 8%, #000, transparent 76%);
+          mask-image: radial-gradient(700px 460px at 72% 8%, #000, transparent 76%);
+  opacity: .55;
+}
+.blob { position: absolute; z-index: -1; border-radius: 50%; filter: blur(70px); opacity: .55; pointer-events: none; }
+.blob.b1 { width: 360px; height: 360px; top: -90px; right: 8%; background: var(--grape-500); animation: float1 18s ease-in-out infinite; }
+.blob.b2 { width: 300px; height: 300px; top: 120px; left: -60px; background: var(--peri-500); animation: float2 22s ease-in-out infinite; }
+.blob.b3 { width: 240px; height: 240px; bottom: -120px; left: 40%; background: var(--lilac-300); animation: float1 26s ease-in-out infinite reverse; }
+@keyframes float1 { 0%,100% { transform: translate(0,0) scale(1); } 50% { transform: translate(-26px, 30px) scale(1.08); } }
+@keyframes float2 { 0%,100% { transform: translate(0,0) scale(1); } 50% { transform: translate(34px, -22px) scale(1.05); } }
+
+.hero-inner {
+  display: grid; grid-template-columns: 1.45fr 1fr; gap: 56px; align-items: center;
+  padding: clamp(64px, 11vw, 116px) 0 clamp(56px, 9vw, 96px);
+}
+@media (max-width: 880px) { .hero-inner { grid-template-columns: 1fr; gap: 40px; } }
+
+.eyebrow {
+  display: inline-block; font-size: .78rem; font-weight: 700;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--accent);
+  background: var(--chip-bg); padding: 7px 15px; border-radius: 999px; margin-bottom: 22px;
+}
+.hero h1 { margin-bottom: .3em; }
+.hero h1 .grad {
+  background: var(--grad); -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: transparent;
+}
+.hero .lead { font-size: clamp(1.05rem, 1.9vw, 1.28rem); color: var(--body); max-width: 56ch; margin-bottom: 12px; }
+.fact-row { display: flex; flex-wrap: wrap; gap: 9px; margin: 26px 0 30px; padding: 0; list-style: none; }
+.fact {
+  font-size: .86rem; color: var(--body); background: var(--card);
+  border: 1px solid var(--line); padding: 7px 14px; border-radius: 999px;
+  backdrop-filter: blur(6px);
+}
+.fact b { color: var(--ink); font-weight: 600; }
+
+.portrait { justify-self: center; position: relative; }
+.portrait img {
+  width: clamp(220px, 26vw, 320px); aspect-ratio: 1; object-fit: cover;
+  border-radius: 30px; border: 1px solid var(--line);
+  box-shadow: var(--shadow-lg); background: var(--bg-soft);
+}
+.portrait::before {
+  content: ""; position: absolute; inset: -16px; border-radius: 42px; z-index: -1;
+  background: var(--grad); opacity: .35; filter: blur(36px);
+}
+
+.btn {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 13px 24px; border-radius: 12px; font-weight: 600; font-size: 1rem;
+  border: 1px solid transparent; cursor: pointer; transition: transform .16s ease, box-shadow .16s ease;
+}
+.btn-primary { background: var(--grad); color: #fff; box-shadow: var(--shadow-lg); }
+.btn-primary:hover { transform: translateY(-2px); color: #fff; }
+.btn-ghost { background: var(--card); color: var(--ink); border-color: var(--line); backdrop-filter: blur(6px); }
+.btn-ghost:hover { transform: translateY(-2px); color: var(--ink); border-color: color-mix(in srgb, var(--accent) 50%, var(--line)); }
+.btn-row { display: flex; flex-wrap: wrap; gap: 13px; }
+
+/* ── Sections ───────────────────────────────────────────────── */
+section.block { padding: clamp(56px, 8vw, 88px) 0; }
+section.block.soft { background: var(--bg-soft); }
+.section-head { max-width: 60ch; margin-bottom: 42px; }
+.section-head .kicker {
+  color: var(--accent); font-weight: 700; font-size: .82rem;
+  letter-spacing: .14em; text-transform: uppercase; margin-bottom: 12px;
+}
+.section-head p { color: var(--muted); margin: 0; }
+
+/* ── Card grid ──────────────────────────────────────────────── */
+.grid { display: grid; gap: 22px; }
+.grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 900px) { .grid.cols-3 { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px) { .grid { grid-template-columns: 1fr !important; } }
+
+.card {
+  position: relative; background: var(--card); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 28px; box-shadow: var(--shadow);
+  display: flex; flex-direction: column; overflow: hidden;
+  backdrop-filter: blur(8px);
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+}
+.card::before {
+  content: ""; position: absolute; inset: 0 0 auto 0; height: 3px;
+  background: var(--grad); opacity: 0; transition: opacity .2s ease;
+}
+.card:hover { transform: translateY(-5px); box-shadow: var(--shadow-lg); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); }
+.card:hover::before { opacity: 1; }
+.card .ico {
+  width: 48px; height: 48px; border-radius: 14px; margin-bottom: 18px;
+  background: var(--grad-soft); color: var(--accent-2);
+  display: grid; place-items: center; font-size: 1.35rem;
+}
+.card h3 { color: var(--ink); margin-bottom: .35em; }
+.card h3 a { color: var(--ink); }
+.card h3 a:hover { color: var(--accent); }
+.card p { color: var(--muted); font-size: .95rem; margin-bottom: 16px; }
+.card .more { margin-top: auto; font-weight: 600; font-size: .92rem; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; }
+.card .more::after { content: "→"; transition: transform .15s ease; }
+.card:hover .more::after { transform: translateX(4px); }
+
+.tag-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 4px 0 16px; padding: 0; list-style: none; }
+.tag {
+  font-size: .76rem; color: var(--body); background: var(--chip-bg);
+  border: 1px solid var(--line); padding: 4px 11px; border-radius: 999px;
+}
+
+/* ── Timeline ───────────────────────────────────────────────── */
+.timeline { border-left: 2px solid var(--line); margin-left: 8px; padding-left: 30px; }
+.tl-item { position: relative; padding-bottom: 36px; }
+.tl-item:last-child { padding-bottom: 0; }
+.tl-item::before {
+  content: ""; position: absolute; left: -38px; top: 5px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--grad); box-shadow: 0 0 0 5px var(--bg);
+}
+.tl-item .date { font-size: .83rem; color: var(--accent); font-weight: 700; letter-spacing: .02em; }
+.tl-item h3 { margin: 6px 0 5px; }
+.tl-item .meta { color: var(--muted); font-size: .93rem; }
+.tl-item .meta strong { color: var(--body); }
+
+/* ── Prose (interior pages) ─────────────────────────────────── */
+.page-head { padding: clamp(48px, 7vw, 76px) 0 8px; }
+.page-head .crumb { color: var(--muted); font-size: .9rem; margin-bottom: 10px; }
+.page-head .crumb a { color: var(--muted); }
+.page-head .crumb a:hover { color: var(--accent); }
+
+.prose { padding: 14px 0 clamp(56px, 8vw, 88px); font-size: 1.04rem; }
+.prose h1, .prose h2, .prose h3 { margin: 1.6em 0 .5em; }
+.prose h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); }
+.prose h2 { padding-bottom: .25em; border-bottom: 1px solid var(--line); }
+.prose > p:first-of-type { font-size: 1.12rem; color: var(--body); }
+.prose ul, .prose ol { margin: 0 0 1.1em; padding-left: 1.3em; }
+.prose li { margin-bottom: .5em; }
+.prose blockquote {
+  margin: 1.3em 0; padding: 4px 20px; border-left: 3px solid var(--accent);
+  background: var(--grad-soft); border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--body);
+}
+.prose blockquote p:last-child { margin-bottom: 0; }
+.prose code {
+  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  font-size: .88em; background: var(--chip-bg); padding: .15em .45em; border-radius: 6px;
+}
+.prose pre {
+  background: var(--card-solid); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: 18px 20px; overflow-x: auto; margin-bottom: 1.2em;
+}
+.prose pre code { background: none; padding: 0; font-size: .86em; }
+.prose img { border-radius: var(--radius-sm); border: 1px solid var(--line); margin: 1.2em 0; }
+.prose a { text-decoration: underline; text-underline-offset: 3px; text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+.prose a:hover { text-decoration-color: var(--accent-2); }
+.prose hr { border: 0; height: 1px; background: var(--line); margin: 2.4em 0; }
+.prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.4em; font-size: .95rem; }
+.prose th, .prose td { padding: 10px 14px; border: 1px solid var(--line); text-align: left; }
+.prose th { background: var(--chip-bg); color: var(--ink); }
+
+/* ── Footer ─────────────────────────────────────────────────── */
+.site-footer { background: var(--bg-soft); border-top: 1px solid var(--line); padding: 54px 0 40px; color: var(--muted); font-size: .92rem; }
+.footer-grid { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 36px; }
+@media (max-width: 720px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
+.site-footer h4 { color: var(--ink); font-size: .95rem; margin-bottom: 14px; }
+.site-footer .blurb { max-width: 42ch; }
+.site-footer ul { list-style: none; padding: 0; }
+.site-footer li { margin-bottom: 9px; }
+.site-footer a { color: var(--body); }
+.site-footer a:hover { color: var(--accent); }
+.footer-bottom {
+  border-top: 1px solid var(--line); margin-top: 36px; padding-top: 22px;
+  display: flex; flex-wrap: wrap; gap: 10px; justify-content: space-between; align-items: center;
+}
+.footer-bottom .sig { font-family: var(--serif); }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,46 @@
+// Minimal, dependency-free interactions.
+(function () {
+  "use strict";
+
+  // Mobile nav toggle
+  var toggle = document.querySelector(".nav-toggle");
+  var links = document.getElementById("nav-links");
+  if (toggle && links) {
+    toggle.addEventListener("click", function () {
+      var open = links.classList.toggle("open");
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+    links.addEventListener("click", function (e) {
+      if (e.target.tagName === "A") {
+        links.classList.remove("open");
+        toggle.setAttribute("aria-expanded", "false");
+      }
+    });
+  }
+
+  // Reveal-on-scroll for cards / timeline items
+  var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var targets = document.querySelectorAll("[data-reveal]");
+  if (reduce || !("IntersectionObserver" in window)) {
+    targets.forEach(function (el) { el.style.opacity = 1; });
+    return;
+  }
+  targets.forEach(function (el) {
+    el.style.opacity = 0;
+    el.style.transform = "translateY(18px)";
+    el.style.transition = "opacity .6s ease, transform .6s ease";
+  });
+  var io = new IntersectionObserver(function (entries) {
+    entries.forEach(function (en) {
+      if (en.isIntersecting) {
+        var el = en.target;
+        var d = el.getAttribute("data-reveal") || 0;
+        el.style.transitionDelay = (d * 70) + "ms";
+        el.style.opacity = 1;
+        el.style.transform = "none";
+        io.unobserve(el);
+      }
+    });
+  }, { threshold: 0.12 });
+  targets.forEach(function (el) { io.observe(el); });
+})();

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+---
+title: Research & Learning Notes
+description: Long-form deep dives, worked from scratch — plus tutorials I keep coming back to.
+---
+
+I write to understand. These are the notes that survived the
+margins — ideas worked out slowly until they were clear enough to
+keep.
+
+## Learning notes
+
+- **[Why Logarithms Rule Statistics](./learning-notes/2025-10-score-fxn/2025-10-27-why-logarithms-rule-statistics.html)**
+  — the score function, and why the log shows up everywhere once you
+  go looking for it. *(Oct 2025)*
+
+- **[ViT vs. Wavelet](./learning-notes/2025-12-vit/index.html)**
+  — comparing vision transformers and wavelet representations, with
+  formatted references. *(Dec 2025)*
+
+## Tutorials
+
+- **[A Beginner&rsquo;s Guide to GitHub](./tutorials/HTML_GitHub_Tutorial.html)**
+  — a from-zero walkthrough. *(v1.5, Jan 2025 · v1.0, Feb 2022)*
+
+## Related
+
+- The **[Reference Library](../reading/)** — annotated paper notes and reading roadmaps.
+- The **[AI × Stat/Math Lit Review](../ai4statmath-litreview/)** — a living literature map.

--- a/index.md
+++ b/index.md
@@ -1,178 +1,93 @@
 ---
+layout: home
 title: Home
-layout: default
+description: >-
+  Yulin Li — Ph.D. candidate in Statistics at Rutgers, working across
+  statistics, machine learning, and music.
+
+intro: >-
+  I&rsquo;m a Ph.D. candidate in the Department of Statistics at
+  Rutgers&ndash;New Brunswick. I think about inference, machine
+  learning, and the mathematics underneath them &mdash; and, away
+  from the page, I make music.
+
+facts:
+  - "<b>Ph.D. Candidate</b> · Statistics, Rutgers&ndash;New Brunswick"
+  - "<b>Research</b> · inference &amp; machine learning"
+  - "<b>Music</b> · conductor, arranger, accompanist"
+
+cards:
+  - icon: "✦"
+    title: "Learning Notes"
+    body: "Long-form deep dives — why logarithms rule statistics, ViT vs. wavelets, and other ideas worked out from scratch."
+    url: "/docs/"
+    tags: ["Statistics", "Machine Learning"]
+    cta: "Read the notes"
+  - icon: "❑"
+    title: "Reference Library"
+    body: "An annotated record of papers I&rsquo;ve read — key insights, open questions, and reading roadmaps."
+    url: "/reading/"
+    tags: ["Papers", "Roadmaps"]
+    cta: "Browse the library"
+  - icon: "◇"
+    title: "AI × Stat/Math Lit Review"
+    body: "A living literature map tracking the conversation between modern AI and the statistical & mathematical foundations it leans on."
+    url: "/ai4statmath-litreview/"
+    tags: ["Survey", "AI4Science"]
+    cta: "Open the map"
+  - icon: "⬡"
+    title: "Hierarchical Agentic Network"
+    body: "A self-organizing architecture built from frozen LLM/tool &ldquo;atoms&rdquo; — teach nothing, wire everything, let coordination evolve."
+    url: "/projects/"
+    tags: ["Agents", "Self-organization"]
+    cta: "See the project"
+  - icon: "♪"
+    title: "Cvocaloid Observatory"
+    body: "A quietly self-updating data dashboard at the crossing of music and statistics."
+    url: "/cvocaloid-observatory/"
+    tags: ["Data", "Music"]
+    cta: "Visit the dashboard"
+  - icon: "⌥"
+    title: "Toolbox"
+    body: "Prompts, workflows, and scratch notes — the working scaffolding behind everything else here."
+    url: "/toolbox/"
+    tags: ["Workflow", "Notes"]
+    cta: "Open the toolbox"
+
+teaching:
+  - when: "Fall 2024 · Rutgers"
+    course: "STAT 596 — Advanced Applied Statistics I"
+    detail: "Teaching Assistant, Department of Statistics, Rutgers University."
+  - when: "Spring 2023 · Boston University"
+    course: "MA 751 — Statistical Machine Learning"
+    detail: "Teaching Assistant, Department of Math &amp; Statistics. Recitations 2 hr/wk · class size ~20."
+  - when: "Spring 2022 · Boston University"
+    course: "MA 575 — Linear Models"
+    detail: "Teaching Assistant across five sections. Recitations 5 hr/wk · class size ~80."
+  - when: "2019 &amp; 2020 · Zhejiang University"
+    course: "MATH 241 — Calculus III"
+    detail: "Teaching Assistant, ZJU&ndash;UIUC Institute. Recitations 4 hr/wk · class size ~40."
+
+music:
+  - when: "Dec 2020"
+    title: "1st Chamber Concert, International Campus ZJU"
+    detail: "Director, Musical Director &amp; Piano Accompanist for the inaugural chamber concert."
+  - when: "2017&ndash;2020"
+    title: "Student Choir, International Campus ZJU"
+    detail: "Musical Director, Conductor &amp; Accompanist for a ~30-voice choir spanning every school and nationality on campus."
+  - when: "Aug 2019"
+    title: "ZJU Freshmen Choral Competition"
+    detail: "Arranger &amp; vocal coach for a 100+ ensemble — University Anthem (SATB), arr. Yulin Li. 2nd-place finalist."
+  - when: "Aug 2017 &amp; 2018"
+    title: "ZJU Freshmen Choral Competition"
+    detail: "Arranger, coach &amp; conductor for 80&ndash;180-voice ensembles among 4000+ participants. 2nd-place finalist (2017)."
 ---
 
-# Home
+This space is hand-built — a small, dependency-free Jekyll theme in
+system fonts, light- and dark-aware, dressed in a periwinkle-to-lilac
+palette I&rsquo;m fond of. It documents a journey across **math**,
+**science**, and **art**, and it grows slowly and on purpose.
 
-This is Yulin's personal space to document her journeys in **math**, **science**, and **art**.
-
-
-
-
-> ***Here I am in**: Jan 2025*
->
-> <img src="./assets/images/2024-rutgers-profile.png" alt="Yulin: Sep 2023" style="max-width: 18rem; width: 30%"/>
-> Ph.D. Candidate  
-> 
-> **Department of Statistics, Rutgers--New Brunswick**
-> 
-
-## Resources
-
-### [Academics](./docs/academic/index.md)
-- **Tutorials**: Learning from sharing.  
-  - [A Beginner's Guide to GitHub](./docs/tutorials/HTML_GitHub_Tutorial.html) (v1.5: 01/2025, v1.0: 02/2022)
-- **Communities**
-  - [**StatsUp AI** (https://statsupai.org)](https://statsupai.org): A frontier information platform for statisticians in AI research and revolution.
-  - [**Lunch Salon**](https://mp.weixin.qq.com/s/yIelqWgUyHuEE4iSJwFYGw): A student-organized media for scientific knowledge sharing.
-    
-    - [ ] `TO-DO: include article links`
-    
-    > **Bio**:
-    > Joint work by 7 of the [ZH1Z](https://en.wikipedia.org/wiki/Zhuhai_No.1_High_School) 2017 graduates.
-    >
-    > **Articles**: `Psychology`x4, `Biochemistry`x3, `Computer Science & Engineering`x3, `Motorsports Technology`x2, `Linguistics`x2, `Architecture`x1, `Math History`x1, `Music`x1
-    >
-    > Last update: 02/04/2019
-    ><div style="padding-left: 3rem">
-    >  <img src="./assets/images/2017-lunch-salon.jpeg" alt="Lunch Salon: 2017"  style="max-height: 10rem" />
-    ></div>
-    >
-    
-- **[My Reference Library](./reading/index.md)**: Reference organizer and reading roadmap.
-
-- **My Favorites in Statistics**: Domain highlights and key insights.
-
-
-### Musical Works
-`Under construction...`
-
-- Performance Videos  
-- Music Scores 
-  - Transcriptions
-  - Compositions
-- Activity Timeline
-
-
-## My Teaching Journey
-### Math & Statistics
-#### PhD-level courses
-  - **STAT 596: Advanced Applied Statistics I** Fall 2024
-      
-      Teaching Assistant, Department of Statistics, Rutgers University
-
-  - **MA 751: Statistical Machine Learning** (Section A2, A3) Spring 2023
-      
-      Teaching Assistant, Department of Math & Statistics, Boston University
-
-      Recitations: 2 hr/wk; Total Class Size: 20
-
-#### Graduate-level courses
-  - **MA 575: Linear Models** (Section B1, B2, B3, B4, B5) Spring 2022
-      
-      Teaching Assistant, Department of Math & Statistics, Boston University
-      
-      Recitations: 5 hr/wk; Total Class Size: 80
-#### Undergraduate-level courses
-  - **MATH 241: Calculus III** (Section ?, ?) Fall 2020
-      
-      Teaching Assistant, ZJU-UIUC Institute, Zhejiang University
-      
-      Recitations: 4 hr/wk; Total Class Size: 40
-  - **MATH 241: Calculus III** (Section ?, ?) Fall 2019
-      
-      Teaching Assistant, ZJU-UIUC Institute, Zhejiang University
-      
-      Recitations: 4 hr/wk; Total Class Size: 40
-        
-### Music
-
-  - **1st Chamber Concert of International Campus, ZJU** Fall 2020
-    
-    Director, Musical Director, Piano Accompanist
-
-    > 
-    > **Event Schedule**: Sunday Dec 6, 2020 `18:30-21:00`
-    > 
-    > *Event Highlights:* **[*Intl-ZJU News*](https://mp.weixin.qq.com/s/4tOWEFEcM4L6ZsTlfMB37w)**
-    > 
-    > **Concert Programme**: 
-    ><div style="padding-left: 3rem">
-    >  <img src="./assets/images/2020-concert-programme-1.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
-    >  <img src="./assets/images/2020-concert-programme-2.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
-    >  <img src="./assets/images/2020-concert-programme-3.jpeg" alt="Concert: 2020"  style="max-width: 30%" />
-    ></div>
-  
-  - **Student Choir of International Campus, ZJU** 2017-2020
-    
-    Musical Director, Conductor, Piano Accompanist
-    
-    > ***Team members***: ~30 students from all schools, years, ages, and nationalities at the *International Campus of Zhejiang University*.
-    > 
-    > ***Performed***: 
-    > * ***Can't Help Falling in Love*** (A cappella) Dec 2020
-    > * ***菊花台*** (SATB) Dec 2019 
-    > * ***Seasons of Love*** (SATB) Dec 2019
-    ><div style="padding-left: 3rem">
-    >  <img src="./assets/images/2019-choir-on-stage.jpeg" alt="Choir: 2019"  style="max-height: 100%" />
-    >  <img src="./assets/images/2019-choir.jpeg" alt="Choir: 2019"  style="max-height: 150px" />
-    ></div>
-    > 
-
-  - **2019 Freshmen Choral Competition of Zhejiang University** Aug 2019
-    
-    Music Arranger, Instrument & Vocal Coach
-    
-    - Team Size: 100+ (representing ZJU-UoE Institute)
-    - Total Participants: 4000+
-    - Performed: 
-      - ***University Anthem***（SATB), arr. Yulin Li (2019)
-      - ***汪峰：我爱你中国***（SATB)
-    - Placement: ***2nd-Place** Finalist*
-
-  - **2018 Freshmen Choral Competition of Zhejiang University** Aug 2018
-    
-    Music Arranger, Instrument & Vocal Coach
-    
-    - Team Size: 80+ (representing ZJU-UoE Institute)
-    - Total Participants: 4000+
-    - Performed: 
-      - ***University Anthem***（SATB), arr. Yulin Li (2018)
-      - ***少年中国说***（SATB), arr. Yulin Li (2018)
-
-  - **2017 Freshmen Choral Competition of Zhejiang University** Aug 2017
-    
-    Music Arranger, Instrument & Vocal Coach, Conductor
-    
-    - Team Size: 180+ (representing ZJU-UIUC Institute)
-    - Total Participants: 4000+
-    - Performed: 
-      - ***University Anthem***（SATB), arr. Xinhai Zhu (2017)
-      - ***生来倔强***（SATB), arr. Yulin Li (2017)
-    - Placement: ***2nd-Place** Finalist*
-
-
-
-
-
-## My Toolboxes
-
-`Under construction...`
-
-### [Projects](./projects/index.md)
-- **Ongoing Projects**  
-
-
-
-### Toolboxes
-- **[Toolbox](./toolbox/index.md)**  
-
-
-
-## About This Site
-
-`Under construction...`
-
-*Last updated: 01-12-2025*
-
+Earlier drafts of the front page are kept in
+[`/archive/homepage`]({{ '/archive/homepage/20260518-index.md' | relative_url }})
+rather than deleted — versioned, not erased.

--- a/projects/HAN-README.md
+++ b/projects/HAN-README.md
@@ -1,3 +1,8 @@
+---
+title: HAN — README
+description: Scope and minimal demonstration of the Hierarchical Agentic Network.
+---
+
 # 🧠 Hierarchical Agentic Network (HAN)
 
 > **A minimal, self-organizing architecture built from frozen LLM atoms.**  

--- a/projects/HAN-discussions.md
+++ b/projects/HAN-discussions.md
@@ -1,4 +1,9 @@
-Absolutely—this is where HAN can get spicy and *alive*. You can let the network **self-organize** via RL by training *only* the wiring, routing, and scheduling policies while keeping each atomic LLM frozen. Think of it as “evolution over circuits,” not neurons.
+---
+title: HAN — Design Discussions
+description: Open threads on self-organization, routing, and scheduling.
+---
+
+This is where HAN gets alive: let the network **self-organize** via RL by training *only* the wiring, routing, and scheduling policies while keeping each atomic LLM frozen — evolution over circuits, not neurons.
 
 # High-level idea
 
@@ -120,7 +125,7 @@ If you want, I can sketch the exact telemetry schema and the first set of node p
 
 ---
 
-Absolutely—this is where HAN can get spicy and *alive*. You can let the network **self-organize** via RL by training *only* the wiring, routing, and scheduling policies while keeping each atomic LLM frozen. Think of it as “evolution over circuits,” not neurons.
+This is where HAN gets alive: let the network **self-organize** via RL by training *only* the wiring, routing, and scheduling policies while keeping each atomic LLM frozen — evolution over circuits, not neurons.
 
 # High-level idea
 

--- a/projects/HAN-overview.md
+++ b/projects/HAN-overview.md
@@ -1,8 +1,9 @@
-Absolutely — here’s a concise, collaborator-friendly **README draft** that captures the *big picture, core logic, and demo scope* without going into internal technicalities.
-
+---
+title: HAN — Overview
+description: The big picture and core logic of the Hierarchical Agentic Network.
 ---
 
-# 🧠 Hierarchical Agentic Network (HAN) – Minimal Demonstration
+# Hierarchical Agentic Network (HAN) — Minimal Demonstration
 
 ### **Overview**
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,0 +1,27 @@
+---
+title: Projects
+description: Things I'm building — research systems and data experiments.
+---
+
+A short list, kept honest. Work in progress is labelled as such.
+
+## Hierarchical Agentic Network (HAN)
+
+A self-organizing architecture built from *frozen* LLM/tool
+&ldquo;atoms.&rdquo; Rather than fine-tuning models, HAN learns only
+**how** these atomic units connect, communicate, and schedule work —
+coordination emerges from a few global rules (energy budget,
+redundancy penalty, reward for progress).
+
+> *Teach nothing. Wire everything. Let coordination evolve.*
+
+- [Overview](./HAN-overview.md) — the big picture and core logic
+- [README](./HAN-README.md) — scope and demonstration
+- [Discussions](./HAN-discussions.md) — open threads and design notes
+
+## Cvocaloid Observatory
+
+A quietly self-updating data dashboard sitting at the crossing of
+music and statistics — refreshed on a daily cadence.
+
+- [Open the dashboard](../cvocaloid-observatory/)

--- a/reading/2025-01-12-argmin-inference.md
+++ b/reading/2025-01-12-argmin-inference.md
@@ -1,3 +1,8 @@
+---
+title: Confidence set for discrete argmin
+description: "Zhang et al. (2024) — Winners with Confidence: Discrete Argmin Inference."
+---
+
 ### **Zhang et al. (2024)** *Winners with Confidence: Discrete Argmin Inference with an Application to Model Selection*  
 **Tianyu Zhang (CMU), Hao Lee (CMU), Jing Lei (CMU)**  
 [arXiv:2408.02060](https://arxiv.org/abs/2408.02060) — *accessed Jan 2025*  

--- a/reading/2025-01-14-comparative-eval.md
+++ b/reading/2025-01-14-comparative-eval.md
@@ -1,3 +1,8 @@
+---
+title: Comparative model evaluations
+description: Su et al. (2024) — Analysis of the ICML 2023 ranking data.
+---
+
 ### **Su et al. (2024)** *Analysis of the ICML 2023 Ranking Data: Can Authors' Opinions of Their Own Papers Assist Peer Review in Machine Learning?*  
 **Buxin Su (UPenn), Jiayao Zhang (UPenn), Natalie Collina (UPenn), Yuling Yan (UW-Madison), Didong Li (UNC), Kyunghyun Cho (NYU), Jianqing Fan (Princeton), Aaron Roth (UPenn), Weijie J. Su (UPenn)**  
 [arXiv:2408.13430](https://arxiv.org/abs/2408.13430) — *accessed Jan, 2025*  

--- a/reading/index.md
+++ b/reading/index.md
@@ -1,25 +1,20 @@
-# Literature Reading Notes
-
-Welcome to my literature reading section. This is where I document thoughts, comments, and brainstorms on academic papers I've read. Each paper has its own dedicated page for detailed notes and insights.
-
-## Recent Reading
-
-### Inference on Inference
-
-- [Confidence set for discrete argmin](./2025-01-12-argmin-inference.md): 
-**Zhang et al. (2024)**: *Winners with Confidence: Discrete Argmin Inference with an Application to Model Selection*. [arXiv:2408.02060](https://arxiv.org/abs/2408.02060).
-
-- [Comparative Model Evaluations](2025-01-14-comparative-eval.md): 
-**Su et al. (2024)**: *Analysis of the ICML 2023 Ranking Data: Can Authors' Opinions of Their Own Papers Assist Peer Review in Machine Learning?*. [arXiv:2408.13430](https://arxiv.org/abs/2408.13430).
-
-
-
-
-## How to Use This Section
-1. **Link to the Paper**: Include a link to the paper on arXiv or another source.
-2. **Notes and Brainstorms**: Add your thoughts, key insights, and questions.
-3. **Tags**: Use topic tags to categorize the paper for easy reference.
-
+---
+title: Reference Library
+description: Annotated notes on papers I've read — insights, open questions, and reading roadmaps.
 ---
 
-_Last updated: [Date]_ by Yulin Li
+Each paper gets its own page: what it claims, what convinced me, and
+the questions I left with.
+
+## Inference on inference
+
+- **[Confidence set for discrete argmin](./2025-01-12-argmin-inference.md)**
+  — Zhang et al. (2024), *Winners with Confidence: Discrete Argmin
+  Inference with an Application to Model Selection*.
+  [arXiv:2408.02060](https://arxiv.org/abs/2408.02060)
+
+- **[Comparative model evaluations](./2025-01-14-comparative-eval.md)**
+  — Su et al. (2024), *Analysis of the ICML 2023 Ranking Data: Can
+  Authors&rsquo; Opinions of Their Own Papers Assist Peer Review in
+  Machine Learning?*
+  [arXiv:2408.13430](https://arxiv.org/abs/2408.13430)

--- a/toolbox/index.md
+++ b/toolbox/index.md
@@ -1,0 +1,22 @@
+---
+title: Toolbox
+description: Prompts, workflows, and scratch notes — the scaffolding behind the rest.
+---
+
+The working bench. Not everything here is polished — that&rsquo;s the
+point.
+
+## Scratch papers
+
+Quick drafts, brainstorms, and half-formed ideas before they earn a
+proper home.
+
+- [Scratch papers index](./scratch-papers/)
+
+## Workflow notes
+
+- Versioning &amp; archiving — old drafts move to
+  [`/archive`]({{ '/archive/homepage/20260518-index.md' | relative_url }})
+  rather than getting deleted.
+- Consistent file naming (`yyyy-mm-dd-topic-title`) across notes and
+  reading entries.

--- a/toolbox/scratch-papers/index.md
+++ b/toolbox/scratch-papers/index.md
@@ -1,0 +1,5 @@
+---
+title: Scratch Papers
+description: Quick drafts and brainstorms before they earn a proper home.
+---
+


### PR DESCRIPTION
## Summary

Retires the bare markdown architecture in favor of a hand-built, **dependency-free** Jekyll theme — system fonts, light/dark aware — dressed in the **Periwinkle–Lilac Staircase** palette. Keeps the structure clean and content-first (cards, timelines, generous whitespace, clear hierarchy) in the spirit of the StatsUpAI pages referenced as liked.

- **Design system**: `_config.yml`, `_layouts` (default / home / page), `_includes` (head / header / footer), `assets/css/main.css`, `assets/js/main.js`. Glassy nav, dreamy gradient hero with floating blobs, card grid, timeline, prose styles; reduced-motion + a11y aware.
- **Home rebuilt**: hero with portrait, work cards, teaching & music timelines, an "About this site" colophon — a *finished* tone with the half-done "Under construction"/TODO clutter removed, while keeping the genuinely strong material (research notes, teaching, music history).
- **Section pages**: filled the previously-empty `docs` / `projects` / `toolbox` indexes; gave leaf pages front matter so they render themed; tidied the reading library.
- **Archived** the prior front page to `archive/homepage/20260518-index.md` (versioned, not erased — following the existing `archive/homepage` convention).
- Trimmed AI-residue opening lines from the HAN docs.

Notes:
- StatsUpAI is a mirror from another org — intentionally **not** featured as personal work; that folder is left untouched.
- Verified with a clean local `jekyll build` (zero warnings); static sub-sites (`statsupai-revamp`, `cvocaloid-observatory`, `ai4statmath-litreview`, Quarto notes) pass through unmodified.

## Test plan

- [ ] GitHub Pages build succeeds on this branch
- [ ] Home renders: hero, 6 work cards, teaching/music timelines, footer
- [ ] Interior pages (`/docs/`, `/reading/`, `/projects/`, `/toolbox/`) render with the prose layout + nav
- [ ] Light and dark mode both look right
- [ ] Mobile nav toggle works
- [ ] Static sub-sites still load unchanged

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_