### PR TITLE
footer: add Stay Connected social row + expand Organization sameAs

### DIFF
--- a/statsupai-revamp/articles.html
+++ b/statsupai-revamp/articles.html
@@ -72,6 +72,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>

--- a/statsupai-revamp/assets/css/main.css
+++ b/statsupai-revamp/assets/css/main.css
@@ -309,6 +309,26 @@ section.block.soft { background: var(--bg-soft); }
 }
 .footer-grid { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 32px; }
 @media (max-width: 760px) { .footer-grid { grid-template-columns: 1fr; gap: 24px; } }
+
+/* ---------- Social row ---------- */
+.social { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin: 4px 0 24px; }
+.social .lbl { color: var(--muted); font-size: .9rem; margin-right: 6px; }
+.social a {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 38px; height: 38px; border-radius: 50%;
+  color: var(--body); background: var(--card);
+  border: 1px solid var(--line);
+  transition: color .15s ease, border-color .15s ease, transform .15s ease;
+}
+.social a:hover {
+  color: var(--accent); border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  transform: translateY(-2px); text-decoration: none;
+}
+.social svg { width: 19px; height: 19px; fill: currentColor; }
+.social .asa-pill {
+  width: auto; padding: 0 13px; font-weight: 800; font-size: .8rem;
+  letter-spacing: .04em; border-radius: 19px;
+}
 .site-footer h4 { color: var(--ink); font-size: .95rem; margin-bottom: 12px; }
 .site-footer ul { list-style: none; padding: 0; margin: 0; }
 .site-footer li { margin-bottom: 8px; }

--- a/statsupai-revamp/community.html
+++ b/statsupai-revamp/community.html
@@ -90,6 +90,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>

--- a/statsupai-revamp/datasets.html
+++ b/statsupai-revamp/datasets.html
@@ -72,6 +72,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>

--- a/statsupai-revamp/events.html
+++ b/statsupai-revamp/events.html
@@ -88,6 +88,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>

--- a/statsupai-revamp/index.html
+++ b/statsupai-revamp/index.html
@@ -26,7 +26,13 @@
     "url": "https://statsupai.org",
     "description": "An ASA interest group empowering statisticians to lead in AI research through curated datasets, review articles, ready-to-use pipelines, community news and a webinar series.",
     "memberOf": { "@type": "Organization", "name": "American Statistical Association", "url": "https://www.amstat.org" },
-    "sameAs": ["https://groups.google.com/g/stats-up-ai/"]
+    "sameAs": [
+      "https://x.com/statsupai",
+      "https://www.linkedin.com/company/stats-up-ai/",
+      "https://www.youtube.com/@StatsUpAI",
+      "https://groups.google.com/g/stats-up-ai/",
+      "https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c"
+    ]
   }
   </script>
   <link rel="stylesheet" href="assets/css/main.css">
@@ -190,6 +196,16 @@
         </ul>
       </div>
     </div>
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span>Revamp concept · static, dependency-free</span>

--- a/statsupai-revamp/pipeline.html
+++ b/statsupai-revamp/pipeline.html
@@ -67,6 +67,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>

--- a/statsupai-revamp/team.html
+++ b/statsupai-revamp/team.html
@@ -64,6 +64,16 @@
 
 <footer class="site-footer">
   <div class="container">
+
+<nav class="social" aria-label="StatsUpAI — stay connected">
+  <span class="lbl">Stay connected</span>
+  <a href="https://x.com/statsupai" target="_blank" rel="noopener" aria-label="StatsUpAI on X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2H21.5l-7.5 8.57L22.5 22h-6.9l-5.41-7.07L4 22H.75l8.02-9.17L1.5 2h7.05l4.9 6.48L18.24 2Zm-1.21 18h1.92L7.05 4H5l12.03 16Z"/></svg></a>
+  <a href="https://www.linkedin.com/company/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI on LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 9h4v12H3zM10 9h3.8v1.7h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V21H18v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21h-4z"/></svg></a>
+  <a href="https://www.youtube.com/@StatsUpAI" target="_blank" rel="noopener" aria-label="StatsUpAI on YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg></a>
+  <a href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener" aria-label="StatsUpAI Google Group"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-8 1.3-8 4v3h10v-3c0-1 .4-2 1.4-2.8A13 13 0 0 0 8 13Zm8 0c-.6 0-1.3 0-1.9.1 1.2.9 1.9 2 1.9 3.9v3h8v-3c0-2.7-5.3-4-8-4Z"/></svg></a>
+  <a href="https://community.amstat.org/communities/community-home?CommunityKey=47facf85-a101-4b92-acf6-019637e3455c" target="_blank" rel="noopener" class="asa-pill" aria-label="StatsUpAI ASA Interest Group (ASA login required)">ASA</a>
+  <a href="mailto:stats-up-ai+managers@googlegroups.com" aria-label="Email the Google Group managers"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Zm1.8 1 7.2 4.9L19.2 6ZM4 7.3V18h16V7.3l-8 5.5Z"/></svg></a>
+</nav>
     <div class="footer-bottom">
       <span>© <span id="year">2026</span> StatsUpAI · statsupai.org</span>
       <span><a href="index.html">Back to home</a></span>


### PR DESCRIPTION
Adds the standard "Stay Connected" footer to every page, using the
official StatsUpAI channel set (from the Google Group email signature):

- X · LinkedIn · YouTube · Google Group · ASA Interest Group · managers email
- Inline SVG icons (no icon-font dependency), accessible `aria-label`s,
  keyboard-focusable, light/dark aware, hover lift.
- Homepage `Organization` JSON-LD `sameAs` now lists all profiles so search
  engines associate them with the org.

Checks pass locally.

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_