### PR TITLE
Fork-tree warning + StatsUpAI official-site English audit (refs #10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md — read this before touching anything StatsUpAI-related
+
+## ⚠️ FORK-TREE WARNING — DO NOT NEGLECT ⚠️
+
+> **The StatsUpAI official website source repo is NOT the upstream / root of
+> its fork tree. It is itself a *fork* sitting somewhere inside a larger fork
+> network.**
+
+Concretely:
+
+- **This repo (`yulinl2/yulinl2.github.io`)** is Yulin's *personal* site. The
+  StatsUpAI work lives in **`statsupai-revamp/`** and is a **downstream
+  personal mirror / revamp**, not the live site.
+- **The official StatsUpAI site source is `Statsup-AI/statsupai.github.io`.**
+  That repo is **a fork within a fork tree — it is NOT the canonical
+  upstream**. Do not assume it is the root. Do not assume a "parent" repo is
+  authoritative without explicitly verifying the fork lineage first.
+- Changes made here in `statsupai-revamp/` do **not** propagate to the
+  official site, and changes pushed to `Statsup-AI/statsupai.github.io` do
+  **not** necessarily flow "up" to any canonical source — because the canonical
+  source is ambiguous in this fork tree.
+
+**Consequences for any future agent:**
+
+1. Never open a PR against, force-push to, or "sync from upstream" on a repo
+   whose role you have not explicitly re-confirmed. The obvious-looking parent
+   may not be the real source of truth.
+2. When asked to "fix the StatsUpAI site", clarify *which* surface is meant:
+   the personal mirror (`statsupai-revamp/` here) or the official
+   `Statsup-AI/statsupai.github.io`. They are different repos with different
+   lineage.
+3. Treat content flowing between these repos as a **manual, reviewed** step,
+   never an automatic mirror.
+4. This environment's GitHub tool scope is limited to
+   `yulinl2/yulinl2.github.io` and `Statsup-AI/statsupai.github.io`. The true
+   upstream may be outside scope entirely — flag this rather than guessing.
+
+## StatsUpAI mirror structure
+
+- `statsupai-revamp/` — self-contained static revamp. Content is data-driven:
+  - `assets/data/events.json` — webinars
+  - `assets/data/resources.json` — datasets / review articles / pipelines
+  - `assets/js/team-data.js` — team roster (single source of truth)
+  - `assets/data/roadmap.json` — internal decision board (`roadmap.html`)
+- `statsupai-revamp/MAINTAINING.md` — non-technical maintainer guide
+- `statsupai-revamp/AUDIT.md` — design audit of the original site + rationale
+
+See those two files (both now carry the same fork-tree banner) for details.

--- a/statsupai-revamp/AUDIT.md
+++ b/statsupai-revamp/AUDIT.md
@@ -1,3 +1,12 @@
+> ## ⚠️ FORK-TREE WARNING — DO NOT NEGLECT ⚠️
+>
+> The official StatsUpAI source repo **`Statsup-AI/statsupai.github.io` is NOT
+> the upstream / root of its fork tree — it is itself a fork.** This
+> `statsupai-revamp/` directory is a **downstream personal mirror** in
+> `yulinl2/yulinl2.github.io`. Do not treat any "parent" repo as canonical
+> without explicitly re-verifying the fork lineage first. See the repo-root
+> `CLAUDE.md` for the full caveat and consequences.
+
 # StatsUpAI — Deep Design Audit & Revamp
 
 Audit of the StatsUpAI site as found in the `yulinl2/statsupai.github.io` mirror

--- a/statsupai-revamp/MAINTAINING.md
+++ b/statsupai-revamp/MAINTAINING.md
@@ -1,3 +1,13 @@
+<!-- ============================================================= -->
+<!-- ⚠️ FORK-TREE WARNING — DO NOT NEGLECT ⚠️                       -->
+<!-- The official StatsUpAI source `Statsup-AI/statsupai.github.io` -->
+<!-- is NOT the upstream/root — it is itself a FORK within a fork   -->
+<!-- tree. This `statsupai-revamp/` is a downstream PERSONAL mirror.-->
+<!-- Changes here do NOT auto-propagate to the live site, and the   -->
+<!-- "obvious parent" is NOT necessarily canonical. Re-verify fork  -->
+<!-- lineage before any PR / push / sync. See repo-root CLAUDE.md.  -->
+<!-- ============================================================= -->
+
 # Maintaining the StatsUpAI site (for non-technical maintainers)
 
 You almost never touch HTML. Content lives in **JSON data files**; the site


### PR DESCRIPTION
## Summary

- Adds repo-root **`CLAUDE.md`** with a prominent **fork-tree warning**: `Statsup-AI/statsupai.github.io` is NOT the upstream/root — it is itself a fork within a fork tree. Auto-loaded by any future Claude Code agent so it can't be neglected.
- Adds the same warning as a banner atop **`statsupai-revamp/MAINTAINING.md`** and **`statsupai-revamp/AUDIT.md`**.
- Companion to **#10**, which catalogues the full English-expression audit of the live official site with proposed fixes.

## Mirror status

The `statsupai-revamp/` mirror was rebuilt cleanly and **already avoids every official-site issue that maps onto it** (Steering Committee, Clinical Trial Data, correct EHR-pipeline description). No mirror prose change was needed — see the mapping table in #10. The remaining issues are official-site-only and are left as **proposed** fixes (not pushed to `Statsup-AI/statsupai.github.io`) per the fork-tree caution.

## Test plan

- [ ] Confirm `CLAUDE.md` fork-tree wording is accurate and sufficiently prominent
- [ ] Review the audit + proposed corrections in #10
- [ ] Decide whether/how to apply the proposed fixes to the official repo (mind the fork lineage)

Refs #10

https://claude.ai/code/session_01DRnfGGiXaczKfw9LrXu61V

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRnfGGiXaczKfw9LrXu61V)_