### PR TITLE
refs: verified X example + document syndication path

### DIFF
--- a/statsupai-revamp/MAINTAINING.md
+++ b/statsupai-revamp/MAINTAINING.md
@@ -55,9 +55,10 @@ When you find a post that documents a talk, drop its URL into
 
 - `match_date` = the talk's `events.json` date if you know it; otherwise add
   the object to `unsorted` and it'll be classified on the next sweep.
-- Individual LinkedIn/X **post** URLs are fetchable even though the
-  company/profile pages are login-walled — so paste the specific post link,
-  not the profile.
+- Individual **post** URLs are fetchable even though the company/profile
+  pages are login-walled — so paste the specific post link, not the profile.
+  LinkedIn `/posts/…` works via its OG preview; X `…/status/<id>` works via
+  the public syndication endpoint (a plain profile/timeline link does not).
 - CI only validates the JSON; the actual cross-check/fill into `events.json`
   happens on the next Claude sweep. The entries are also listed on the
   Decision Board page for visibility.

--- a/statsupai-revamp/assets/data/reference-links.json
+++ b/statsupai-revamp/assets/data/reference-links.json
@@ -7,6 +7,12 @@
       "match_date": "2026-05-26",
       "platform": "linkedin",
       "note": "Naim Rashid talk — verified, already in events.json. Example entry."
+    },
+    {
+      "url": "https://x.com/statsupai/status/2049208693133087060",
+      "match_date": "2026-05-08",
+      "platform": "x",
+      "note": "Curtis Huttenhower (Harvard) Health-series seminar — verified via syndication endpoint, matches events.json. Example X entry."
     }
   ],
   "unsorted": []


### PR DESCRIPTION
Capability finding + worked example for the paste interface.

**X individual tweets are readable** via the public syndication endpoint
(`cdn.syndication.twimg.com/tweet-result?id=…`) even though WebFetch, the
profile page, and the timeline endpoint all return HTTP 402. So both
LinkedIn (`/posts/…`) and X (`…/status/<id>`) work as **per-permalink**
reference sources — neither timeline is enumerable, which is exactly what
`reference-links.json` is designed around.

- Added the StatsUpAI Huttenhower tweet as the worked X example in
  `reference-links.json`; it independently **verifies** the May 8 2026
  Health-series talk already in `events.json`.
- `MAINTAINING.md` updated to note the X syndication path (paste the
  `status/<id>` permalink, not the profile).

No new access; checks pass locally.

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_