### PR TITLE
events P1: enriched collapsible cards + real logo

### DIFF
--- a/statsupai-revamp/articles.html
+++ b/statsupai-revamp/articles.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">

--- a/statsupai-revamp/assets/css/main.css
+++ b/statsupai-revamp/assets/css/main.css
@@ -7,6 +7,9 @@
   --teal-600: #088080;
   --teal-500: #0a9c9c;
   --teal-050: #e7f4f4;
+  --indigo-600: #4f46b8;
+  --indigo-500: #635bd6;
+  --indigo-050: #ecebfa;
   --ink: #14201f;
   --body: #44524f;
   --muted: #6b7a77;
@@ -413,3 +416,73 @@ hr.div { border: 0; height: 1px; background: var(--line); margin: 48px 0; }
 .event-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
 .btn-sm { padding: 8px 14px; font-size: .9rem; border-radius: 9px; }
 .event-actions .meta { align-self: center; }
+
+/* ---------- Brand logo lockup ---------- */
+.brand-logo {
+  height: 34px; width: auto; display: block; border-radius: 6px;
+}
+@media (max-width: 480px) { .brand-logo { height: 28px; } }
+
+/* ---------- Events: enriched collapsible cards ---------- */
+.ev-series-head {
+  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+  margin: 36px 0 18px; padding-bottom: 10px; border-bottom: 1px solid var(--line);
+}
+.ev-series-head h2 { margin: 0; font-size: 1.35rem; }
+.ev-series-head .sub { color: var(--muted); font-size: .95rem; }
+.ev-list { display: grid; gap: 16px; }
+
+.evcard {
+  --accent-s: var(--teal-600);
+  position: relative; background: var(--card);
+  border: 1px solid var(--line); border-radius: var(--radius);
+  box-shadow: var(--shadow); overflow: hidden;
+}
+.evcard.s-GenAI { --accent-s: var(--indigo-600); }
+.evcard::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+  background: var(--accent-s);
+}
+.evcard .pad { padding: 20px 22px 20px 26px; }
+.evcard.is-past { opacity: .92; }
+
+.ev-top { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 8px; }
+.ev-chip {
+  font-size: .72rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  padding: 4px 10px; border-radius: 999px;
+  color: var(--accent-s); background: color-mix(in srgb, var(--accent-s) 12%, transparent);
+}
+.ev-when { font-size: .9rem; color: var(--body); font-weight: 600; }
+.ev-status {
+  font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  padding: 3px 9px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted);
+}
+.ev-status.up { color: #1f7a4d; border-color: #1f7a4d55; background: #1f7a4d12; }
+@media (prefers-color-scheme: dark) { .ev-status.up { color: #5fd39b; } }
+
+.evcard h3 { font-size: 1.12rem; margin: 2px 0 6px; color: var(--ink); }
+.ev-speaker { margin: 0 0 4px; font-size: .98rem; color: var(--body); }
+.ev-speaker a { font-weight: 600; }
+.ev-speaker .aff { color: var(--muted); }
+
+.ev-platform { display: inline-flex; align-items: center; gap: 6px; font-size: .82rem; color: var(--muted); }
+.ev-platform svg { width: 16px; height: 16px; fill: currentColor; }
+
+details.ev-disc { margin-top: 12px; border-top: 1px dashed var(--line); padding-top: 10px; }
+details.ev-disc summary {
+  cursor: pointer; font-weight: 600; font-size: .92rem; color: var(--accent-s);
+  list-style: none; display: flex; align-items: center; gap: 7px;
+}
+details.ev-disc summary::-webkit-details-marker { display: none; }
+details.ev-disc summary::before {
+  content: "▸"; transition: transform .15s ease; font-size: .8em;
+}
+details.ev-disc[open] summary::before { transform: rotate(90deg); }
+details.ev-disc .body {
+  margin: 10px 0 2px; color: var(--body); font-size: .94rem; line-height: 1.6;
+  max-width: 75ch;
+}
+@media (prefers-reduced-motion: reduce) { details.ev-disc summary::before { transition: none; } }
+
+.ev-cta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 14px; }
+.ev-empty { color: var(--muted); padding: 8px 0 4px; }

--- a/statsupai-revamp/assets/data/events.json
+++ b/statsupai-revamp/assets/data/events.json
@@ -1,119 +1,129 @@
 {
-  "_comment": "SINGLE SOURCE OF TRUTH for webinars. Non-technical maintainers: add an object to talks, commit. CI validates it; the site auto-sorts upcoming vs past by date and builds calendar links. date = ISO YYYY-MM-DD. time_et like '12:00 PM'. series = 'Health' | 'GenAI'. Compiled from the stats-up-ai@googlegroups.com announcements.",
+  "_comment": "SINGLE SOURCE OF TRUTH for webinars. Schema per talk: date (YYYY-MM-DD), time_et, duration_min, speaker, speaker_full, affiliation, personal_website, title, series (Health|GenAI), abstract, bio, registration_link, recording_link, recording_platform. Empty string = unknown (do not fabricate). Provenance in _reference/talks.md & sources.md.",
   "series": {
-    "Health": { "label": "Health Data Science Series", "tagline": "Statistical and AI methods for health data science — neuroimaging, genomics, EHR, microbiome and more." },
-    "GenAI": { "label": "GenAI × Statistics Series", "tagline": "Bridging the gap between generative AI and statistical methodologies." }
+    "Health": { "label": "Health Data Science Series", "full": "Statistical and AI Methods for Health Data Science", "tagline": "Statistical & AI methods across neuroimaging, genomics, EHR, microbiome and clinical data." },
+    "GenAI": { "label": "GenAI × Statistics Series", "full": "Generative AI and Statistics", "tagline": "Bridging the gap between generative AI and statistical methodology." }
   },
   "talks": [
     {
-      "date": "2025-04-09",
-      "time_et": "12:00 PM",
-      "duration_min": 60,
-      "speaker": "Martin Lindquist",
+      "date": "2025-04-09", "time_et": "12:00 PM", "duration_min": 60,
+      "speaker": "Martin Lindquist", "speaker_full": "Dr. Martin Lindquist",
       "affiliation": "Johns Hopkins University",
+      "personal_website": "https://sites.google.com/view/martinlindquist/home",
       "title": "Elements of Functional Neuroimaging",
       "series": "Health",
+      "abstract": "The field of neuroimaging, particularly functional magnetic resonance imaging (fMRI), is rapidly growing, with over 1,000 new publications annually and widespread use across diverse academic disciplines. As fMRI becomes a core tool for psychologists, neuroscientists, physicians, economists, lawyers, and engineers, understanding its intricacies has never been more critical. However, the interdisciplinary nature of neuroimaging presents challenges due to its combination of necessary biological, computational, statistical, and psychological expertise. This talk seeks to provide an accessible overview of how fMRI works, focusing on its underlying principles, and explain the variety of techniques used to analyze fMRI data. We will focus on essential conceptual tools to critically evaluate fMRI studies, avoid common pitfalls, and deepen the understanding of this powerful imaging technique.",
+      "bio": "Martin Lindquist is a Professor of Biostatistics at Johns Hopkins University. His research focuses on mathematical and statistical problems relating to functional Magnetic Resonance Imaging (fMRI). He has published over 100 articles and serves on the editorial boards of several scientific journals in statistics and neuroimaging. He is a fellow of the American Statistical Association. In 2018 he received the Organization for Human Brain Mapping's 'Education in Neuroimaging Award' for online classes that have taught fMRI methods to more than 100,000 students worldwide.",
       "registration_link": "https://upenn.zoom.us/j/94227327976",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2025-05-08",
-      "time_et": "3:00 PM",
-      "duration_min": 60,
-      "speaker": "Ying Guo",
+      "date": "2025-05-08", "time_et": "3:00 PM", "duration_min": 60,
+      "speaker": "Ying Guo", "speaker_full": "Dr. Ying Guo",
       "affiliation": "Emory University",
+      "personal_website": "https://www.yingguo.us/",
       "title": "Exploring Brain Function and Connectivity with fMRI: From Data Characteristics to Statistical and AI Methods",
       "series": "Health",
+      "abstract": "Neuroimaging technology has played a central role in advancing scientific understanding of normal brain function in humans, as well as in investigating the neural basis of psychiatric and neurological disorders. Among the various neuroimaging techniques, functional magnetic resonance imaging (fMRI) is one of the most commonly used tools in current neuroscience studies. This talk introduces analytical techniques and statistical methods for investigating brain function and connectivity using fMRI, beginning with the background and key characteristics of fMRI data relevant to statistical modeling, followed by an overview of fMRI analysis with a focus on brain network and connectome analysis using statistical and AI-based approaches.",
+      "bio": "Dr. Ying Guo is Professor in the Department of Biostatistics and Bioinformatics at Emory University, an appointed Graduate Faculty of the Emory Neuroscience Program, and Associate Faculty in Emory's Department of Computer Science. She is a founding member and current Director of the Center for Biomedical Imaging Statistics (CBIS) at Emory. Her research focuses on analytical methods for neuroimaging and mental-health studies including blind source separation, brain network and connectome methods, and multimodal imaging. She is a Fellow of the ASA and served as the 2023 Chair of the ASA Statistics in Imaging Section.",
       "registration_link": "https://upenn.zoom.us/j/99182616852",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2025-06-06",
-      "time_et": "11:00 AM",
-      "duration_min": 60,
-      "speaker": "Hernando Ombao",
+      "date": "2025-06-06", "time_et": "11:00 AM", "duration_min": 60,
+      "speaker": "Hernando Ombao", "speaker_full": "Dr. Hernando Ombao",
       "affiliation": "King Abdullah University of Science and Technology (KAUST)",
+      "personal_website": "https://www.kaust.edu.sa/en/study/faculty/hernando-ombao",
       "title": "Overview of Methods for Characterizing Brain Functional Connectivity",
       "series": "Health",
+      "abstract": "",
+      "bio": "Hernando Ombao is a Professor in the Statistics Program and principal investigator of the Biostatistics Group at KAUST. His research develops time-series models and data-science methods for analyzing high-dimensional complex biological processes, with emphasis on spectral and time-series analysis, functional data analysis, state-space models, and signal processing for brain signals and images.",
       "registration_link": "https://upenn.zoom.us/j/91348715596",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2025-07-16",
-      "time_et": "12:00 PM",
-      "duration_min": 60,
-      "speaker": "Dana Tudorascu",
+      "date": "2025-07-16", "time_et": "12:00 PM", "duration_min": 60,
+      "speaker": "Dana Tudorascu", "speaker_full": "Dr. Dana Tudorascu",
       "affiliation": "University of Pittsburgh",
+      "personal_website": "https://www.psychiatry.pitt.edu/about-us/our-people/faculty/dana-l-tudorascu-phd",
       "title": "Statistical and AI Methods for Health Data Science Seminar — PET imaging",
       "series": "Health",
+      "abstract": "",
+      "bio": "Dana Tudorascu is an Associate Professor of Psychiatry and Biostatistics at the University of Pittsburgh. Her research interests include neuroimaging studies of age-related pathology, statistical methods for multimodal imaging studies, and Alzheimer's disease.",
       "registration_link": "https://upenn.zoom.us/meeting/register/ucStTTtNTTWxFCamXtt9Fw",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2025-12-02",
-      "time_et": "1:00 PM",
-      "duration_min": 60,
-      "speaker": "Ani Eloyan",
+      "date": "2025-12-02", "time_et": "1:00 PM", "duration_min": 60,
+      "speaker": "Ani Eloyan", "speaker_full": "Dr. Ani Eloyan",
       "affiliation": "Brown University",
+      "personal_website": "http://www.anieloyan.com/",
       "title": "Manifold Learning for Modeling Shapes in Alzheimer's Disease",
       "series": "Health",
+      "abstract": "",
+      "bio": "Ani Eloyan is Associate Professor and Vice Chair in the Department of Biostatistics, School of Public Health at Brown University. Her research interests are statistical analysis of brain images, multivariate analysis of high-dimensional data, and Bayesian analysis of large data.",
       "registration_link": "https://upenn.zoom.us/meeting/register/SL8s_eubT-6qoVoMJRsK6w",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2026-01-09",
-      "time_et": "12:00 PM",
-      "duration_min": 60,
-      "speaker": "Andrew Saykin",
+      "date": "2026-01-09", "time_et": "12:00 PM", "duration_min": 60,
+      "speaker": "Andrew Saykin", "speaker_full": "Dr. Andrew J. Saykin",
       "affiliation": "Indiana University School of Medicine",
-      "title": "Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine",
+      "personal_website": "https://medicine.iu.edu/faculty/6962/saykin-andrew",
+      "title": "Deconstructing Alzheimer's Disease and Related Dementias to Enable Precision Medicine: Challenges, Models, and Resources for Data Science",
       "series": "Health",
+      "abstract": "Alzheimer's disease (AD) and related dementia (ADRD) research has become increasingly big data-driven, relying on large, heterogeneous, and longitudinal datasets spanning imaging, biomarkers, genetics, and clinical phenotyping. Although plaques and tangles have been known for over a century, the underlying causes of most forms of AD/ADRD remain unknown. This lecture discusses foundational questions and challenges in ADRD research, how data science/AI can advance precision diagnostic and therapeutic strategies, and introduces the growing ensemble of accessible data resources (e.g., NACC, ADNI and affiliated neuroimaging, genetics, and multi-omics repositories) along with data-harmonization efforts and the increasing use of large-scale electronic health records.",
+      "bio": "Dr. Andrew J. Saykin, Psy.D., is the Raymond C. Beeler Professor of Radiology and Imaging Sciences and Professor of Medical and Molecular Genetics at the Indiana University School of Medicine. He directs the Indiana Alzheimer's Disease Research Center and the IU Center for Neuroimaging, leads the ADNI Genetics Core, and is an MPI of several NIA-sponsored consortia (CLEAR-AD, KBASE, AI4AD). He is the founding editor-in-chief of Brain Imaging and Behavior and a highly cited author with over 700 publications.",
       "registration_link": "https://upenn.zoom.us/meeting/register/uA1Jh_J8T3Wez4q0rbpTLQ",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2026-01-16",
-      "time_et": "12:00 PM",
-      "duration_min": 60,
-      "speaker": "Mine Çetinkaya-Rundel",
+      "date": "2026-01-16", "time_et": "12:00 PM", "duration_min": 60,
+      "speaker": "Mine Çetinkaya-Rundel", "speaker_full": "Dr. Mine Çetinkaya-Rundel",
       "affiliation": "Duke University",
+      "personal_website": "https://mine-cr.com/",
       "title": "Leveraging LLMs for student feedback in introductory data science courses",
       "series": "GenAI",
+      "abstract": "A considerable recent challenge for learners and teachers of data science courses is the increasing use of LLM-based tools in generating answers. In this talk I introduce an R package that leverages LLMs to produce immediate feedback on student work to motivate them to attempt it themselves first. I discuss the technical details of augmenting models with course materials, backend and user-interface decisions, challenges around evaluations the LLM does not perform correctly, and student feedback from the first set of users — and address ethical considerations for a formal assessment structure that relies on LLMs.",
+      "bio": "Mine Çetinkaya-Rundel is a Professor of the Practice and Director of Undergraduate Studies in the Department of Statistical Science at Duke University, and Director of the First-Year Experience in Trinity College of Arts & Sciences. Her work focuses on innovation in statistics and data science pedagogy, with emphasis on computing, reproducible research, student-centered learning, and open-source education. She is a contributor to the OpenIntro Statistics textbook and develops R packages and resources for data science education.",
       "registration_link": "https://upenn.zoom.us/meeting/register/7iwjCrS6Qia0EbrBodLyQw#/registration",
-      "recording_link": "https://www.youtube.com/watch?v=uwCr5xlRBs4"
+      "recording_link": "https://www.youtube.com/watch?v=uwCr5xlRBs4", "recording_platform": "youtube"
     },
     {
-      "date": "2026-02-11",
-      "time_et": "1:00 PM",
-      "duration_min": 60,
-      "speaker": "James Zou",
+      "date": "2026-02-11", "time_et": "1:00 PM", "duration_min": 60,
+      "speaker": "James Zou", "speaker_full": "Dr. James Zou",
       "affiliation": "Stanford University",
+      "personal_website": "https://www.james-zou.com",
       "title": "AI agents to accelerate scientific discoveries",
       "series": "GenAI",
+      "abstract": "AI agents — large language models equipped with tools and reasoning capabilities — are emerging as powerful research enablers. This talk explores how agentic AI can accelerate scientific discoveries. I first introduce the Virtual Lab, a collaborative team of AI scientist agents conducting in-silico research meetings to tackle open-ended research projects; as an example, the Virtual Lab designed new nanobody binders to recent Covid variants that we experimentally validated. I then introduce Paper2Agent, a framework to automatically convert passive research papers into interactive AI agents, and finally discuss learnings from Agents4Science, the first conference where the authors and reviewers are primarily AI systems.",
+      "bio": "James Zou is an Associate Professor of Biomedical Data Science and, by courtesy, Computer Science and Electrical Engineering at Stanford University, and leads the Stanford AI for Science Lab. His research focuses on making AI more reliable and human-compatible, with particular interest in applications for human disease and health. He is a two-time Chan-Zuckerberg Investigator and has received the Overton Prize, NSF CAREER Award, and Sloan Fellowship.",
       "registration_link": "https://sfu.zoom.us/meeting/register/3MLcnkc9TJCYfHNrdVSbeQ#/registration",
-      "recording_link": "https://www.youtube.com/watch?v=pl_ek2PvFb0"
+      "recording_link": "https://www.youtube.com/watch?v=pl_ek2PvFb0", "recording_platform": "youtube"
     },
     {
-      "date": "2026-05-08",
-      "time_et": "2:00 PM",
-      "duration_min": 60,
-      "speaker": "Curtis Huttenhower",
+      "date": "2026-05-08", "time_et": "2:00 PM", "duration_min": 60,
+      "speaker": "Curtis Huttenhower", "speaker_full": "Dr. Curtis Huttenhower",
       "affiliation": "Harvard T.H. Chan School of Public Health",
+      "personal_website": "https://huttenhower.sph.harvard.edu/home/",
       "title": "Quantitative methods for microbial communities and the human microbiome",
       "series": "Health",
+      "abstract": "Statistical methods for microbial community research have evolved to address most of the tasks necessary for end-to-end environmental or human population study design and execution — power calculations, data handling and denoising, simulation and evaluation, and biostatistics for phenotypic and covariate analysis — all accounting for the well-established properties of microbial ecology data (compositionality, sparsity, nonindependence). This talk reviews the state of the art and discusses solutions for linear modeling, mediation analysis, and omnibus testing, providing a flexible toolkit for the most commonly needed quantitative analyses in microbial community science.",
+      "bio": "Curtis Huttenhower is a Professor of Computational Biology and Bioinformatics in the Department of Biostatistics at the Harvard T.H. Chan School of Public Health. His research focuses on computational biology at the intersection of microbial community function and human health, including the biomolecular functions of the human microbiome and the metabolic and functional roles of microbial communities enabled by high-throughput sequencing.",
       "registration_link": "https://us02web.zoom.us/meeting/register/6V5L7h7YQ0-qs6JqnElBfg",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     },
     {
-      "date": "2026-05-26",
-      "time_et": "2:00 PM",
-      "duration_min": 60,
-      "speaker": "Naim Rashid",
+      "date": "2026-05-26", "time_et": "2:00 PM", "duration_min": 60,
+      "speaker": "Naim Rashid", "speaker_full": "Dr. Naim Rashid",
       "affiliation": "University of North Carolina–Chapel Hill",
+      "personal_website": "https://naimurashid.github.io/",
       "title": "Staying in the Driver's Seat: Calibrating AI Use in Statistical Research, Training, and Practice",
       "series": "GenAI",
+      "abstract": "Generative AI tools have become part of daily statistical research and training. They can accelerate everyday tasks, help us work in unfamiliar coding frameworks, and reduce the friction of writing first drafts — but as we use AI for more substantive parts of our work, how do we stay actively engaged with the choices and reasoning embedded in its output? This talk presents principles, daily habits, and project-level practices for using AI effectively while maintaining genuine ownership of our work, grounded in pre-AI cognitive science on tool use, learning, and expert intuition, as well as emerging peer-reviewed evidence on AI use in learning contexts.",
+      "bio": "Naim Rashid, PhD, is an Associate Professor of Biostatistics at the UNC Gillings School of Global Public Health with a joint appointment at the UNC Lineberger Comprehensive Cancer Center. His group develops statistical and machine-learning methods for precision oncology, spanning adaptive and Bayesian trial design, deep learning, and high-dimensional inference for genomic data. He serves on the Nature Medicine Statistical Advisory Panel and the V Foundation Scientific Advisory Board and is an Associate Editor of the Annals of Applied Statistics.",
       "registration_link": "https://sfu.zoom.us/meeting/register/t_dkc6edSq2ql2STmKquqw",
-      "recording_link": ""
+      "recording_link": "", "recording_platform": ""
     }
   ]
 }

--- a/statsupai-revamp/assets/js/render.js
+++ b/statsupai-revamp/assets/js/render.js
@@ -105,6 +105,10 @@
   /* ---------------- Events ---------------- */
   var evRoot = document.getElementById("events-root");
   if (evRoot) {
+    var IC = {
+      youtube: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 12s0-3.2-.4-4.6a3 3 0 0 0-2.1-2.1C18.9 5 12 5 12 5s-6.9 0-8.5.3A3 3 0 0 0 1.4 7.4 32 32 0 0 0 1 12s0 3.2.4 4.6a3 3 0 0 0 2.1 2.1C5.1 19 12 19 12 19s6.9 0 8.5-.3a3 3 0 0 0 2.1-2.1c.4-1.4.4-4.6.4-4.6ZM10 15V9l5.2 3-5.2 3Z"/></svg>',
+      zoom: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm15 2.2 3.4-2.3a.6.6 0 0 1 .9.5v9.2a.6.6 0 0 1-.9.5L18 14.8Z"/></svg>'
+    };
     getJSON("assets/data/events.json").then(function (data) {
       var today = new Date();
       today.setHours(0, 0, 0, 0);
@@ -119,7 +123,7 @@
 
       function fmt(d) {
         return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
-          month: "short", day: "numeric", year: "numeric"
+          weekday: "short", month: "short", day: "numeric", year: "numeric"
         });
       }
       function ics(t) {
@@ -130,59 +134,74 @@
           "UID:" + start + "-" + encodeURIComponent(t.speaker) + "@statsupai.org",
           "DTSTART;VALUE=DATE:" + start,
           "SUMMARY:" + t.title.replace(/[,;]/g, "") + " — " + t.speaker,
-          "DESCRIPTION:" + (data.series[t.series] ? data.series[t.series].label : t.series) +
+          "DESCRIPTION:" + (data.series[t.series] ? data.series[t.series].full : t.series) +
             (t.registration_link ? "\\nRegister: " + t.registration_link : ""),
           "END:VEVENT", "END:VCALENDAR"
         ];
         return "data:text/calendar;charset=utf-8," + encodeURIComponent(lines.join("\r\n"));
       }
+      function disc(label, text) {
+        if (!text) return "";
+        return '<details class="ev-disc"><summary>' + esc(label) +
+          '</summary><div class="body">' + esc(text) + "</div></details>";
+      }
       function card(t, isUpcoming) {
-        var ser = data.series[t.series] ? data.series[t.series].label : t.series;
-        var actions = isUpcoming
+        var sname = data.series[t.series] ? data.series[t.series].label : t.series;
+        var spk = t.personal_website
+          ? '<a href="' + esc(t.personal_website) + '" target="_blank" rel="noopener">' + esc(t.speaker_full || t.speaker) + "</a>"
+          : esc(t.speaker_full || t.speaker);
+        var platform = "";
+        if (!isUpcoming && t.recording_link) {
+          platform = '<span class="ev-platform">' + (IC[t.recording_platform] || "") +
+            (t.recording_platform === "youtube" ? "Recording on YouTube" : "Recording available") + "</span>";
+        } else if (isUpcoming && t.registration_link) {
+          platform = '<span class="ev-platform">' + IC.zoom + "Online · Zoom (registration)</span>";
+        }
+        var cta = isUpcoming
           ? (t.registration_link
-              ? '<a class="btn btn-primary btn-sm" href="' + esc(t.registration_link) + '" target="_blank" rel="noopener">Register</a>'
-              : "") +
+              ? '<a class="btn btn-primary btn-sm" href="' + esc(t.registration_link) + '" target="_blank" rel="noopener">Register</a>' : "") +
             '<a class="btn btn-ghost btn-sm" href="' + ics(t) + '" download="statsupai-' + t.date + '.ics">Add to calendar</a>'
           : (t.recording_link
-              ? '<a class="btn btn-ghost btn-sm" href="' + esc(t.recording_link) + '" target="_blank" rel="noopener">Watch recording</a>'
-              : '<span class="meta">Recording TBA</span>');
-        var d = el("div", "event");
-        d.innerHTML =
-          '<span class="date">' + fmt(t.date) + " · " + esc(t.time_et) + " ET</span>" +
-          '<span class="badge">' + esc(t.series) + "</span>" +
+              ? '<a class="btn btn-primary btn-sm" href="' + esc(t.recording_link) + '" target="_blank" rel="noopener">Watch recording</a>'
+              : '<span class="ev-status">Recording TBA</span>');
+        var c = el("article", "evcard s-" + esc(t.series) + (isUpcoming ? "" : " is-past"));
+        c.innerHTML =
+          '<div class="pad">' +
+          '<div class="ev-top">' +
+            '<span class="ev-chip">' + esc(sname) + "</span>" +
+            '<span class="ev-when">' + fmt(t.date) + " · " + esc(t.time_et) + " ET</span>" +
+            '<span class="ev-status ' + (isUpcoming ? "up" : "") + '">' + (isUpcoming ? "Upcoming" : "Past") + "</span>" +
+          "</div>" +
           "<h3>" + esc(t.title) + "</h3>" +
-          '<p class="meta">' + esc(t.speaker) + " · " + esc(t.affiliation) + " · <em>" + esc(ser) + "</em></p>" +
-          '<div class="event-actions">' + actions + "</div>";
-        return d;
+          '<p class="ev-speaker">' + spk + ' <span class="aff">· ' + esc(t.affiliation) + "</span></p>" +
+          (platform ? '<p style="margin:6px 0 0">' + platform + "</p>" : "") +
+          disc("Abstract", t.abstract) +
+          disc("Speaker bio", t.bio) +
+          '<div class="ev-cta">' + cta + "</div>" +
+          "</div>";
+        return c;
       }
-
-      var html = "";
-      var up = el("div");
-      up.appendChild(el("div", "section-head",
-        '<div class="kicker">Upcoming</div><h2>Next talks</h2>'));
-      if (upcoming.length) {
-        var tl = el("div", "timeline");
-        upcoming.forEach(function (t) { tl.appendChild(card(t, true)); });
-        up.appendChild(tl);
-      } else {
-        up.appendChild(el("p", "meta", "No upcoming talks scheduled — check back soon."));
-      }
-
-      var pa = el("div");
-      pa.style.marginTop = "48px";
-      pa.appendChild(el("div", "section-head",
-        '<div class="kicker">Archive</div><h2>Past talks</h2>'));
-      if (past.length) {
-        var tl2 = el("div", "timeline");
-        past.forEach(function (t) { tl2.appendChild(card(t, false)); });
-        pa.appendChild(tl2);
-      } else {
-        pa.appendChild(el("p", "meta", "Archive coming soon."));
+      function section(title, sub, arr, isUp, emptyMsg) {
+        var wrap = el("div");
+        wrap.innerHTML = '<div class="ev-series-head"><h2>' + esc(title) +
+          '</h2><span class="sub">' + esc(sub) + "</span></div>";
+        if (arr.length) {
+          var list = el("div", "ev-list");
+          arr.forEach(function (t) { list.appendChild(card(t, isUp)); });
+          wrap.appendChild(list);
+        } else {
+          wrap.appendChild(el("p", "ev-empty", emptyMsg));
+        }
+        return wrap;
       }
 
       evRoot.innerHTML = "";
-      evRoot.appendChild(up);
-      evRoot.appendChild(pa);
+      evRoot.appendChild(section("Upcoming", upcoming.length + " scheduled", upcoming, true,
+        "No upcoming talks scheduled — check back soon."));
+      var pastWrap = section("Past talks", past.length + " in the archive", past, false,
+        "Archive coming soon.");
+      pastWrap.style.marginTop = "44px";
+      evRoot.appendChild(pastWrap);
 
       // Event JSON-LD (Google event rich results)
       var ld = talks.map(function (t) {

--- a/statsupai-revamp/community.html
+++ b/statsupai-revamp/community.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">

--- a/statsupai-revamp/datasets.html
+++ b/statsupai-revamp/datasets.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">

--- a/statsupai-revamp/events.html
+++ b/statsupai-revamp/events.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">
@@ -39,22 +39,22 @@
   <div class="container page-head">
     <p class="crumb"><a href="index.html">Home</a> → Events</p>
     <h1>Events &amp; Webinars</h1>
-    <p>Two ongoing series bridging statistical methodology and modern AI. Registration
-    links are on the live site.</p>
+    <p>Two ongoing webinar series. Each talk below carries its full abstract and
+    speaker bio (tap to expand), registration or recording link, and an
+    add-to-calendar action.</p>
   </div>
 
   <section class="block">
     <div class="container">
       <div class="grid cols-2" style="margin-bottom:40px">
-        <article class="card">
-          <h3>Health Data Science Series</h3>
-          <p>Big-data and AI methods for health, imaging, genetics and clinical phenotyping.</p>
-          <a class="more" href="https://statsupai.org/events/webinars/#health-data-science-series" target="_blank" rel="noopener">See series</a>
+        <article class="card" style="border-left:4px solid var(--teal-600)">
+          <h3>Statistical &amp; AI Methods for Health Data Science</h3>
+          <p>Statistical &amp; AI methods across neuroimaging, genomics, EHR,
+          microbiome and clinical data.</p>
         </article>
-        <article class="card">
-          <h3>GenAI × Statistics Series</h3>
-          <p>Bridging the gap between generative AI and statistical methodologies.</p>
-          <a class="more" href="https://statsupai.org/events/webinars/#genai-stats-series" target="_blank" rel="noopener">See series</a>
+        <article class="card" style="border-left:4px solid var(--indigo-600)">
+          <h3>Generative AI and Statistics</h3>
+          <p>Bridging the gap between generative AI and statistical methodology.</p>
         </article>
       </div>
 

--- a/statsupai-revamp/index.html
+++ b/statsupai-revamp/index.html
@@ -43,7 +43,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">
@@ -173,7 +173,7 @@
   <div class="container">
     <div class="footer-grid">
       <div>
-        <a class="brand" href="index.html"><span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span></a>
+        <a class="brand" href="index.html"><img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span></a>
         <p style="margin-top:14px;max-width:42ch">Statistics shaping the future of Artificial
         Intelligence. An ASA interest group, open to all.</p>
       </div>

--- a/statsupai-revamp/pipeline.html
+++ b/statsupai-revamp/pipeline.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">

--- a/statsupai-revamp/roadmap.html
+++ b/statsupai-revamp/roadmap.html
@@ -16,7 +16,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <span class="lbl" style="color:var(--muted)">Internal · Decision Board</span>
   </div>

--- a/statsupai-revamp/team.html
+++ b/statsupai-revamp/team.html
@@ -20,7 +20,7 @@
 <header class="site-header">
   <div class="container nav">
     <a class="brand" href="index.html" aria-label="StatsUpAI home">
-      <span class="mark">S</span><span>Stats<span class="up">Up</span>AI</span>
+      <img class="brand-logo" src="assets/img/logo.png" alt="StatsUpAI" width="44" height="37"><span>Stats<span class="up">Up</span>AI</span>
     </a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links">☰ Menu</button>
     <ul class="nav-links" id="nav-links">


### PR DESCRIPTION
**P1 deliverable.** The Events page is now a professionally enriched,
data-driven archive.

`assets/data/events.json` enriched schema per talk: speaker_full,
affiliation, personal_website, time, **abstract**, **speaker bio**,
registration, recording + platform. 10 talks. Abstracts are verbatim from
the source announcement emails/X; bios factual (faculty pages for the 3
without an official abstract — **no fabrication**, empty where unknown).

Renderer rebuilt:
- **Upcoming / Past** sections, sorted, with counts
- **Series color-coding** — Health = teal, GenAI = indigo — via a left
  accent bar + chip
- Card: series chip · full date · time ET · Upcoming/Past status; title;
  **speaker linked to their homepage** · affiliation; **Zoom/YouTube
  platform icon**
- **Collapsible `<details>`** for Abstract and Speaker bio (progressive
  disclosure; real semantics, keyboard/reduced-motion friendly)
- CTAs: Register / Add to calendar (.ics) for upcoming; Watch recording
  (or "Recording TBA") for past
- **Real StatsUpAI logo** in the brand lockup site-wide (gradient mark kept
  only as favicon)

Design rationale documented in `_reference/DESIGN-NOTES.md`. CI green.

Part of #15. Next: dataset child pages, Zotero-driven articles, team +2,
pipelines fidelity, community enrichment.

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_