### PR TITLE
Quiet the theme: dusty mint–mauve palette, smaller headshot

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
     </div>
     <div class="footer-bottom">
       <span class="sig">© {{ 'now' | date: "%Y" }} Yulin Li</span>
-      <span>Built with care · periwinkle &amp; lilac</span>
+      <span>Built quietly · dusty mint &amp; mauve</span>
     </div>
   </div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,11 +3,11 @@
 <title>{% if page.title and page.url != "/" %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }} — {{ site.tagline }}{% endif %}</title>
 <meta name="description" content="{{ page.description | default: site.description }}">
 <meta name="author" content="{{ site.author }}">
-<meta name="theme-color" content="#6687ff">
+<meta name="theme-color" content="#faf8f7">
 <meta property="og:title" content="{{ page.title | default: site.title }}">
 <meta property="og:description" content="{{ page.description | default: site.description }}">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
 <link rel="canonical" href="{{ site.url }}{{ page.url }}">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%236687ff'/%3E%3Cstop offset='1' stop-color='%23a866ff'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='9' fill='url(%23g)'/%3E%3Ctext x='16' y='22' font-family='Georgia,serif' font-size='17' fill='white' text-anchor='middle'%3EY%3C/text%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='9' fill='%23f3eff0'/%3E%3Ctext x='16' y='22' font-family='Georgia,serif' font-size='17' fill='%235e8a7c' text-anchor='middle'%3EY%3C/text%3E%3C/svg%3E">
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,9 +2,6 @@
 layout: default
 ---
 <section class="hero">
-  <span class="blob b1"></span>
-  <span class="blob b2"></span>
-  <span class="blob b3"></span>
   <div class="container hero-inner">
     <div>
       <span class="eyebrow">{{ site.tagline }}</span>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,6 @@
 layout: default
 ---
 <section class="hero">
-  <span class="blob b2"></span>
   <div class="container page-head">
     <p class="crumb"><a href="{{ '/' | relative_url }}">Home</a> &nbsp;/&nbsp; {{ page.title | default: "Page" }}</p>
     <h1>{{ page.title | default: "Untitled" }}</h1>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,42 +1,42 @@
 /* ────────────────────────────────────────────────────────────
    Yulin Li — personal site design system
    Dependency-free · system fonts · light/dark aware
-   Palette: Periwinkle–Lilac Staircase (蓝紫云梯)
+   Calm, editorial, low-key. Piano-quiet.
+
+   Palette (preserved for reuse): "dusty-mint-mauve-ribbon"
+   — Dusty Mint → Mauve Ribbon (低饱和薄荷到玫灰丝带)
+   source swatches: #b3d1cb #b3c8d1 #b3b9d1 #bbb3d1 #cbb3d1
    ──────────────────────────────────────────────────────────── */
 
 :root {
-  /* core palette */
-  --peri-600: #4f6bff;
-  --peri-500: #6687ff;
-  --peri-300: #adbfff;
-  --peri-200: #d1dbff;
-  --lilac-200: #e5d1ff;
-  --lilac-300: #d1adff;
-  --grape-500: #a866ff;
-  --grape-700: #7d3fe0;
+  /* source palette */
+  --mint:       #b3d1cb;
+  --mint-blue:  #b3c8d1;
+  --perigrey:   #b3b9d1;
+  --mauve-200:  #bbb3d1;
+  --mauve-300:  #cbb3d1;
+  /* derived, slightly deeper for legible accents */
+  --sage-ink:   #5e8a7c;
+  --mauve-ink:  #9b7a8f;
 
-  /* semantic — light */
-  --ink: #21244a;
-  --body: #4b4f78;
-  --muted: #7d80ad;
-  --line: rgba(102, 135, 255, .20);
-  --bg: #f6f6ff;
-  --bg-soft: #eceeff;
-  --card: rgba(255, 255, 255, .72);
+  /* semantic — light (warm, paper-like) */
+  --ink: #2c2b30;
+  --body: #585660;
+  --muted: #8d8a93;
+  --line: #e8e3e4;
+  --bg: #faf8f7;
+  --bg-soft: #f3eff0;
+  --card: #ffffff;
   --card-solid: #ffffff;
-  --accent: var(--peri-600);
-  --accent-2: var(--grape-500);
+  --accent: var(--sage-ink);
+  --accent-2: var(--mauve-ink);
   --accent-ink: #ffffff;
-  --chip-bg: rgba(102, 135, 255, .10);
+  --chip-bg: #eef2f0;
 
-  --grad: linear-gradient(135deg, var(--peri-500) 0%, var(--grape-500) 100%);
-  --grad-soft: linear-gradient(135deg, var(--peri-200), var(--lilac-200));
-
-  --radius: 18px;
-  --radius-sm: 12px;
-  --shadow: 0 2px 6px rgba(79, 107, 255, .07), 0 18px 48px -20px rgba(125, 63, 224, .28);
-  --shadow-lg: 0 10px 40px -12px rgba(102, 135, 255, .35);
-  --maxw: 1140px;
+  --radius: 14px;
+  --radius-sm: 10px;
+  --shadow: 0 1px 2px rgba(60, 56, 60, .04), 0 10px 28px -22px rgba(60, 56, 60, .25);
+  --maxw: 1080px;
 
   --font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, ui-serif, serif;
@@ -44,21 +44,19 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --ink: #ecedff;
-    --body: #c4c7ef;
-    --muted: #9094c6;
-    --line: rgba(173, 191, 255, .16);
-    --bg: #0d0f2b;
-    --bg-soft: #14173a;
-    --card: rgba(40, 44, 88, .50);
-    --card-solid: #181b3d;
-    --accent: #94a9ff;
-    --accent-2: #c9adff;
-    --accent-ink: #14163a;
-    --chip-bg: rgba(148, 169, 255, .12);
-    --shadow: 0 2px 6px rgba(0, 0, 0, .35), 0 22px 56px -22px rgba(0, 0, 0, .65);
-    --shadow-lg: 0 12px 44px -10px rgba(125, 63, 224, .45);
-    --grad-soft: linear-gradient(135deg, rgba(102, 135, 255, .22), rgba(168, 102, 255, .22));
+    --ink: #ece8ea;
+    --body: #c0bcc4;
+    --muted: #8f8b95;
+    --line: #2a282e;
+    --bg: #181619;
+    --bg-soft: #1f1d22;
+    --card: #201e23;
+    --card-solid: #201e23;
+    --accent: #9cc0b4;
+    --accent-2: #c6a9bb;
+    --accent-ink: #1a181b;
+    --chip-bg: #26242a;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 14px 34px -22px rgba(0,0,0,.6);
   }
 }
 
@@ -69,11 +67,10 @@ body {
   font-family: var(--font);
   color: var(--body);
   background: var(--bg);
-  line-height: 1.68;
+  line-height: 1.72;
   font-size: 17px;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-  overflow-x: hidden;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -81,151 +78,119 @@ body {
   *, *::before, *::after { animation: none !important; transition: none !important; }
 }
 
-h1, h2, h3, h4 { color: var(--ink); line-height: 1.16; font-weight: 700; letter-spacing: -.02em; }
-h1 { font-family: var(--serif); font-weight: 600; font-size: clamp(2.3rem, 5.4vw, 3.7rem); letter-spacing: -.015em; }
-h2 { font-size: clamp(1.55rem, 3.2vw, 2.25rem); margin-bottom: .5em; }
-h3 { font-size: 1.18rem; }
+h1, h2, h3, h4 { color: var(--ink); line-height: 1.22; font-weight: 600; letter-spacing: -.01em; }
+h1 { font-family: var(--serif); font-weight: 500; font-size: clamp(2rem, 3.8vw, 2.9rem); letter-spacing: -.005em; }
+h2 { font-family: var(--serif); font-weight: 500; font-size: clamp(1.4rem, 2.5vw, 1.85rem); margin-bottom: .5em; }
+h3 { font-size: 1.1rem; }
 p { margin-bottom: 1em; }
 
 a { color: var(--accent); text-decoration: none; transition: color .15s ease; }
 a:hover { color: var(--accent-2); }
 img { max-width: 100%; display: block; }
-::selection { background: rgba(168, 102, 255, .25); }
+::selection { background: rgba(155, 122, 143, .18); }
 
 .container { width: 100%; max-width: var(--maxw); margin-inline: auto; padding-inline: 24px; }
-.narrow { max-width: 760px; }
+.narrow { max-width: 720px; }
 
 .skip-link {
   position: absolute; left: 12px; top: -52px; z-index: 200;
   background: var(--accent); color: var(--accent-ink);
-  padding: 10px 16px; border-radius: 10px; transition: top .15s ease;
+  padding: 10px 16px; border-radius: 8px; transition: top .15s ease;
 }
 .skip-link:focus { top: 12px; }
-:focus-visible { outline: 3px solid var(--grape-500); outline-offset: 3px; border-radius: 5px; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 4px; }
 
 /* ── Header / nav ───────────────────────────────────────────── */
 .site-header {
   position: sticky; top: 0; z-index: 100;
-  background: color-mix(in srgb, var(--bg) 78%, transparent);
-  backdrop-filter: saturate(180%) blur(14px);
-  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
   border-bottom: 1px solid var(--line);
 }
-.nav { display: flex; align-items: center; justify-content: space-between; height: 70px; gap: 16px; }
-.brand { display: flex; align-items: center; gap: 11px; font-weight: 700; font-size: 1.12rem; color: var(--ink); letter-spacing: -.02em; }
+.nav { display: flex; align-items: center; justify-content: space-between; height: 66px; gap: 16px; }
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 600; font-size: 1.05rem; color: var(--ink); letter-spacing: -.01em; }
 .brand:hover { color: var(--ink); }
 .brand .mark {
-  width: 34px; height: 34px; border-radius: 11px; background: var(--grad);
-  display: grid; place-items: center; color: #fff; font-weight: 700;
-  font-family: var(--serif); font-size: 1rem; box-shadow: var(--shadow-lg);
+  width: 30px; height: 30px; border-radius: 9px;
+  background: var(--bg-soft); border: 1px solid var(--line);
+  display: grid; place-items: center; color: var(--accent);
+  font-family: var(--serif); font-size: .95rem;
 }
-.nav-links { display: flex; align-items: center; gap: 4px; list-style: none; }
+.nav-links { display: flex; align-items: center; gap: 2px; list-style: none; }
 .nav-links a {
-  display: block; padding: 9px 15px; border-radius: 10px;
-  color: var(--body); font-weight: 500; font-size: .96rem;
+  display: block; padding: 8px 14px; border-radius: 8px;
+  color: var(--body); font-weight: 500; font-size: .94rem;
 }
-.nav-links a:hover { background: var(--chip-bg); color: var(--ink); }
-.nav-links a[aria-current="page"] { color: var(--accent); background: var(--chip-bg); }
+.nav-links a:hover { background: var(--bg-soft); color: var(--ink); }
+.nav-links a[aria-current="page"] { color: var(--accent); }
 .nav-toggle {
   display: none; background: none; border: 1px solid var(--line);
-  color: var(--ink); border-radius: 10px; padding: 9px 12px; cursor: pointer; font-size: 1.05rem;
+  color: var(--ink); border-radius: 8px; padding: 8px 11px; cursor: pointer; font-size: 1.02rem;
 }
 @media (max-width: 820px) {
   .nav-toggle { display: inline-flex; }
   .nav-links {
-    position: absolute; inset: 70px 0 auto 0; flex-direction: column; align-items: stretch;
+    position: absolute; inset: 66px 0 auto 0; flex-direction: column; align-items: stretch;
     background: var(--bg); border-bottom: 1px solid var(--line);
-    padding: 12px 18px 20px; gap: 2px; display: none;
+    padding: 10px 18px 18px; gap: 2px; display: none;
   }
   .nav-links.open { display: flex; }
-  .nav-links a { padding: 13px 14px; }
+  .nav-links a { padding: 12px 14px; }
 }
 
 /* ── Hero ───────────────────────────────────────────────────── */
-.hero { position: relative; overflow: hidden; isolation: isolate; }
-.hero::before {
-  content: ""; position: absolute; inset: 0; z-index: -2;
-  background:
-    radial-gradient(900px 520px at 82% -8%, rgba(168, 102, 255, .30), transparent 60%),
-    radial-gradient(820px 480px at 6% 4%, rgba(102, 135, 255, .26), transparent 58%),
-    var(--bg);
-}
-.hero::after {
-  content: ""; position: absolute; inset: 0; z-index: -1; pointer-events: none;
-  background-image:
-    linear-gradient(var(--line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--line) 1px, transparent 1px);
-  background-size: 52px 52px;
-  -webkit-mask-image: radial-gradient(700px 460px at 72% 8%, #000, transparent 76%);
-          mask-image: radial-gradient(700px 460px at 72% 8%, #000, transparent 76%);
-  opacity: .55;
-}
-.blob { position: absolute; z-index: -1; border-radius: 50%; filter: blur(70px); opacity: .55; pointer-events: none; }
-.blob.b1 { width: 360px; height: 360px; top: -90px; right: 8%; background: var(--grape-500); animation: float1 18s ease-in-out infinite; }
-.blob.b2 { width: 300px; height: 300px; top: 120px; left: -60px; background: var(--peri-500); animation: float2 22s ease-in-out infinite; }
-.blob.b3 { width: 240px; height: 240px; bottom: -120px; left: 40%; background: var(--lilac-300); animation: float1 26s ease-in-out infinite reverse; }
-@keyframes float1 { 0%,100% { transform: translate(0,0) scale(1); } 50% { transform: translate(-26px, 30px) scale(1.08); } }
-@keyframes float2 { 0%,100% { transform: translate(0,0) scale(1); } 50% { transform: translate(34px, -22px) scale(1.05); } }
-
+.hero { position: relative; border-bottom: 1px solid var(--line); }
 .hero-inner {
-  display: grid; grid-template-columns: 1.45fr 1fr; gap: 56px; align-items: center;
-  padding: clamp(64px, 11vw, 116px) 0 clamp(56px, 9vw, 96px);
+  display: grid; grid-template-columns: 1fr auto; gap: 48px; align-items: center;
+  padding: clamp(52px, 8vw, 92px) 0 clamp(48px, 7vw, 76px);
 }
-@media (max-width: 880px) { .hero-inner { grid-template-columns: 1fr; gap: 40px; } }
+@media (max-width: 760px) { .hero-inner { grid-template-columns: 1fr; gap: 32px; } }
 
 .eyebrow {
-  display: inline-block; font-size: .78rem; font-weight: 700;
-  letter-spacing: .14em; text-transform: uppercase; color: var(--accent);
-  background: var(--chip-bg); padding: 7px 15px; border-radius: 999px; margin-bottom: 22px;
+  display: inline-block; font-size: .76rem; font-weight: 600;
+  letter-spacing: .16em; text-transform: uppercase; color: var(--muted);
+  margin-bottom: 20px;
 }
-.hero h1 { margin-bottom: .3em; }
-.hero h1 .grad {
-  background: var(--grad); -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent; color: transparent;
-}
-.hero .lead { font-size: clamp(1.05rem, 1.9vw, 1.28rem); color: var(--body); max-width: 56ch; margin-bottom: 12px; }
-.fact-row { display: flex; flex-wrap: wrap; gap: 9px; margin: 26px 0 30px; padding: 0; list-style: none; }
-.fact {
-  font-size: .86rem; color: var(--body); background: var(--card);
-  border: 1px solid var(--line); padding: 7px 14px; border-radius: 999px;
-  backdrop-filter: blur(6px);
-}
-.fact b { color: var(--ink); font-weight: 600; }
+.hero h1 { margin-bottom: .35em; max-width: 18ch; }
+.hero h1 .grad { color: var(--accent); }
+.hero .lead { font-size: clamp(1.02rem, 1.6vw, 1.18rem); color: var(--body); max-width: 54ch; margin-bottom: 8px; }
+.fact-row { display: flex; flex-wrap: wrap; gap: 8px 18px; margin: 22px 0 28px; padding: 0; list-style: none; }
+.fact { font-size: .88rem; color: var(--muted); }
+.fact b { color: var(--body); font-weight: 600; }
+.fact + .fact { padding-left: 18px; border-left: 1px solid var(--line); }
+@media (max-width: 520px) { .fact + .fact { padding-left: 0; border-left: 0; } }
 
-.portrait { justify-self: center; position: relative; }
+.portrait { justify-self: center; }
 .portrait img {
-  width: clamp(220px, 26vw, 320px); aspect-ratio: 1; object-fit: cover;
-  border-radius: 30px; border: 1px solid var(--line);
-  box-shadow: var(--shadow-lg); background: var(--bg-soft);
-}
-.portrait::before {
-  content: ""; position: absolute; inset: -16px; border-radius: 42px; z-index: -1;
-  background: var(--grad); opacity: .35; filter: blur(36px);
+  width: clamp(104px, 12vw, 136px); aspect-ratio: 1; object-fit: cover;
+  border-radius: 50%; border: 1px solid var(--line);
+  background: var(--bg-soft);
 }
 
 .btn {
-  display: inline-flex; align-items: center; gap: 9px;
-  padding: 13px 24px; border-radius: 12px; font-weight: 600; font-size: 1rem;
-  border: 1px solid transparent; cursor: pointer; transition: transform .16s ease, box-shadow .16s ease;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 11px 20px; border-radius: 9px; font-weight: 500; font-size: .96rem;
+  border: 1px solid transparent; cursor: pointer; transition: background .16s ease, border-color .16s ease, color .16s ease;
 }
-.btn-primary { background: var(--grad); color: #fff; box-shadow: var(--shadow-lg); }
-.btn-primary:hover { transform: translateY(-2px); color: #fff; }
-.btn-ghost { background: var(--card); color: var(--ink); border-color: var(--line); backdrop-filter: blur(6px); }
-.btn-ghost:hover { transform: translateY(-2px); color: var(--ink); border-color: color-mix(in srgb, var(--accent) 50%, var(--line)); }
-.btn-row { display: flex; flex-wrap: wrap; gap: 13px; }
+.btn-primary { background: var(--accent); color: var(--accent-ink); }
+.btn-primary:hover { background: var(--accent-2); color: var(--accent-ink); }
+.btn-ghost { background: transparent; color: var(--ink); border-color: var(--line); }
+.btn-ghost:hover { background: var(--bg-soft); color: var(--ink); }
+.btn-row { display: flex; flex-wrap: wrap; gap: 12px; }
 
 /* ── Sections ───────────────────────────────────────────────── */
-section.block { padding: clamp(56px, 8vw, 88px) 0; }
+section.block { padding: clamp(48px, 7vw, 80px) 0; }
 section.block.soft { background: var(--bg-soft); }
-.section-head { max-width: 60ch; margin-bottom: 42px; }
+.section-head { max-width: 56ch; margin-bottom: 38px; }
 .section-head .kicker {
-  color: var(--accent); font-weight: 700; font-size: .82rem;
-  letter-spacing: .14em; text-transform: uppercase; margin-bottom: 12px;
+  color: var(--muted); font-weight: 600; font-size: .76rem;
+  letter-spacing: .16em; text-transform: uppercase; margin-bottom: 12px;
 }
 .section-head p { color: var(--muted); margin: 0; }
 
 /* ── Card grid ──────────────────────────────────────────────── */
-.grid { display: grid; gap: 22px; }
+.grid { display: grid; gap: 18px; }
 .grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
 .grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
 @media (max-width: 900px) { .grid.cols-3 { grid-template-columns: repeat(2, 1fr); } }
@@ -233,98 +198,91 @@ section.block.soft { background: var(--bg-soft); }
 
 .card {
   position: relative; background: var(--card); border: 1px solid var(--line);
-  border-radius: var(--radius); padding: 28px; box-shadow: var(--shadow);
-  display: flex; flex-direction: column; overflow: hidden;
-  backdrop-filter: blur(8px);
-  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+  border-radius: var(--radius); padding: 26px;
+  display: flex; flex-direction: column;
+  transition: border-color .18s ease, box-shadow .18s ease;
 }
-.card::before {
-  content: ""; position: absolute; inset: 0 0 auto 0; height: 3px;
-  background: var(--grad); opacity: 0; transition: opacity .2s ease;
-}
-.card:hover { transform: translateY(-5px); box-shadow: var(--shadow-lg); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); }
-.card:hover::before { opacity: 1; }
+.card:hover { border-color: color-mix(in srgb, var(--accent) 35%, var(--line)); box-shadow: var(--shadow); }
 .card .ico {
-  width: 48px; height: 48px; border-radius: 14px; margin-bottom: 18px;
-  background: var(--grad-soft); color: var(--accent-2);
-  display: grid; place-items: center; font-size: 1.35rem;
+  width: 38px; height: 38px; border-radius: 10px; margin-bottom: 16px;
+  background: var(--chip-bg); color: var(--accent);
+  display: grid; place-items: center; font-size: 1.05rem;
 }
-.card h3 { color: var(--ink); margin-bottom: .35em; }
+.card h3 { color: var(--ink); margin-bottom: .35em; font-weight: 600; }
 .card h3 a { color: var(--ink); }
 .card h3 a:hover { color: var(--accent); }
-.card p { color: var(--muted); font-size: .95rem; margin-bottom: 16px; }
-.card .more { margin-top: auto; font-weight: 600; font-size: .92rem; color: var(--accent); display: inline-flex; align-items: center; gap: 7px; }
+.card p { color: var(--muted); font-size: .93rem; margin-bottom: 14px; }
+.card .more { margin-top: auto; font-weight: 500; font-size: .9rem; color: var(--accent); display: inline-flex; align-items: center; gap: 6px; }
 .card .more::after { content: "→"; transition: transform .15s ease; }
-.card:hover .more::after { transform: translateX(4px); }
+.card:hover .more::after { transform: translateX(3px); }
 
-.tag-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 4px 0 16px; padding: 0; list-style: none; }
+.tag-row { display: flex; flex-wrap: wrap; gap: 7px; margin: 2px 0 14px; padding: 0; list-style: none; }
 .tag {
-  font-size: .76rem; color: var(--body); background: var(--chip-bg);
-  border: 1px solid var(--line); padding: 4px 11px; border-radius: 999px;
+  font-size: .74rem; color: var(--muted); background: var(--chip-bg);
+  padding: 3px 10px; border-radius: 999px;
 }
 
 /* ── Timeline ───────────────────────────────────────────────── */
-.timeline { border-left: 2px solid var(--line); margin-left: 8px; padding-left: 30px; }
-.tl-item { position: relative; padding-bottom: 36px; }
+.timeline { border-left: 1px solid var(--line); margin-left: 6px; padding-left: 28px; }
+.tl-item { position: relative; padding-bottom: 32px; }
 .tl-item:last-child { padding-bottom: 0; }
 .tl-item::before {
-  content: ""; position: absolute; left: -38px; top: 5px;
-  width: 13px; height: 13px; border-radius: 50%;
-  background: var(--grad); box-shadow: 0 0 0 5px var(--bg);
+  content: ""; position: absolute; left: -33px; top: 7px;
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 0 4px var(--bg);
 }
-.tl-item .date { font-size: .83rem; color: var(--accent); font-weight: 700; letter-spacing: .02em; }
-.tl-item h3 { margin: 6px 0 5px; }
-.tl-item .meta { color: var(--muted); font-size: .93rem; }
+.tl-item .date { font-size: .82rem; color: var(--muted); font-weight: 600; letter-spacing: .02em; }
+.tl-item h3 { margin: 5px 0 4px; font-weight: 600; }
+.tl-item .meta { color: var(--muted); font-size: .92rem; }
 .tl-item .meta strong { color: var(--body); }
 
 /* ── Prose (interior pages) ─────────────────────────────────── */
-.page-head { padding: clamp(48px, 7vw, 76px) 0 8px; }
-.page-head .crumb { color: var(--muted); font-size: .9rem; margin-bottom: 10px; }
+.page-head { padding: clamp(44px, 6vw, 68px) 0 6px; }
+.page-head .crumb { color: var(--muted); font-size: .88rem; margin-bottom: 12px; }
 .page-head .crumb a { color: var(--muted); }
 .page-head .crumb a:hover { color: var(--accent); }
 
-.prose { padding: 14px 0 clamp(56px, 8vw, 88px); font-size: 1.04rem; }
-.prose h1, .prose h2, .prose h3 { margin: 1.6em 0 .5em; }
-.prose h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); }
+.prose { padding: 14px 0 clamp(48px, 7vw, 80px); font-size: 1.03rem; }
+.prose h1, .prose h2, .prose h3 { margin: 1.7em 0 .5em; }
+.prose h1 { font-size: clamp(1.7rem, 3.4vw, 2.3rem); }
 .prose h2 { padding-bottom: .25em; border-bottom: 1px solid var(--line); }
-.prose > p:first-of-type { font-size: 1.12rem; color: var(--body); }
+.prose > p:first-of-type { font-size: 1.1rem; color: var(--body); }
 .prose ul, .prose ol { margin: 0 0 1.1em; padding-left: 1.3em; }
-.prose li { margin-bottom: .5em; }
+.prose li { margin-bottom: .45em; }
 .prose blockquote {
-  margin: 1.3em 0; padding: 4px 20px; border-left: 3px solid var(--accent);
-  background: var(--grad-soft); border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  color: var(--body);
+  margin: 1.3em 0; padding: 2px 20px; border-left: 2px solid var(--accent);
+  color: var(--muted); font-style: italic;
 }
 .prose blockquote p:last-child { margin-bottom: 0; }
 .prose code {
   font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
-  font-size: .88em; background: var(--chip-bg); padding: .15em .45em; border-radius: 6px;
+  font-size: .88em; background: var(--chip-bg); padding: .15em .45em; border-radius: 5px;
 }
 .prose pre {
-  background: var(--card-solid); border: 1px solid var(--line);
+  background: var(--bg-soft); border: 1px solid var(--line);
   border-radius: var(--radius-sm); padding: 18px 20px; overflow-x: auto; margin-bottom: 1.2em;
 }
 .prose pre code { background: none; padding: 0; font-size: .86em; }
 .prose img { border-radius: var(--radius-sm); border: 1px solid var(--line); margin: 1.2em 0; }
-.prose a { text-decoration: underline; text-underline-offset: 3px; text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+.prose a { text-decoration: underline; text-underline-offset: 3px; text-decoration-color: color-mix(in srgb, var(--accent) 40%, transparent); }
 .prose a:hover { text-decoration-color: var(--accent-2); }
 .prose hr { border: 0; height: 1px; background: var(--line); margin: 2.4em 0; }
 .prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.4em; font-size: .95rem; }
-.prose th, .prose td { padding: 10px 14px; border: 1px solid var(--line); text-align: left; }
-.prose th { background: var(--chip-bg); color: var(--ink); }
+.prose th, .prose td { padding: 9px 14px; border: 1px solid var(--line); text-align: left; }
+.prose th { background: var(--bg-soft); color: var(--ink); }
 
 /* ── Footer ─────────────────────────────────────────────────── */
-.site-footer { background: var(--bg-soft); border-top: 1px solid var(--line); padding: 54px 0 40px; color: var(--muted); font-size: .92rem; }
+.site-footer { background: var(--bg-soft); border-top: 1px solid var(--line); padding: 50px 0 38px; color: var(--muted); font-size: .9rem; }
 .footer-grid { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 36px; }
-@media (max-width: 720px) { .footer-grid { grid-template-columns: 1fr; gap: 26px; } }
-.site-footer h4 { color: var(--ink); font-size: .95rem; margin-bottom: 14px; }
+@media (max-width: 720px) { .footer-grid { grid-template-columns: 1fr; gap: 24px; } }
+.site-footer h4 { color: var(--ink); font-size: .92rem; font-weight: 600; margin-bottom: 14px; }
 .site-footer .blurb { max-width: 42ch; }
 .site-footer ul { list-style: none; padding: 0; }
 .site-footer li { margin-bottom: 9px; }
 .site-footer a { color: var(--body); }
 .site-footer a:hover { color: var(--accent); }
 .footer-bottom {
-  border-top: 1px solid var(--line); margin-top: 36px; padding-top: 22px;
+  border-top: 1px solid var(--line); margin-top: 34px; padding-top: 20px;
   display: flex; flex-wrap: wrap; gap: 10px; justify-content: space-between; align-items: center;
 }
 .footer-bottom .sig { font-family: var(--serif); }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,15 +27,15 @@
   }
   targets.forEach(function (el) {
     el.style.opacity = 0;
-    el.style.transform = "translateY(18px)";
-    el.style.transition = "opacity .6s ease, transform .6s ease";
+    el.style.transform = "translateY(9px)";
+    el.style.transition = "opacity .45s ease, transform .45s ease";
   });
   var io = new IntersectionObserver(function (entries) {
     entries.forEach(function (en) {
       if (en.isIntersecting) {
         var el = en.target;
         var d = el.getAttribute("data-reveal") || 0;
-        el.style.transitionDelay = (d * 70) + "ms";
+        el.style.transitionDelay = (d * 40) + "ms";
         el.style.opacity = 1;
         el.style.transform = "none";
         io.unobserve(el);

--- a/index.md
+++ b/index.md
@@ -84,8 +84,8 @@ music:
 ---
 
 This space is hand-built — a small, dependency-free Jekyll theme in
-system fonts, light- and dark-aware, dressed in a periwinkle-to-lilac
-palette I&rsquo;m fond of. It documents a journey across **math**,
+system fonts, light- and dark-aware, kept deliberately quiet in a
+dusty mint-and-mauve palette. It documents a journey across **math**,
 **science**, and **art**, and it grows slowly and on purpose.
 
 Earlier drafts of the front page are kept in


### PR DESCRIPTION
## Summary

Tones the site down to a calm, editorial, low-key feel — piano-quiet, Anthropic-ish restraint.

- **Palette → `dusty-mint-mauve-ribbon`** (light, greyish-pink + mint). Recorded by name in the CSS header comment so the preference is preserved for future reuse. Warm paper background, desaturated sage + mauve accents, no gradients.
- **Less loud**: removed the hero blobs, grid mask, and gradient text; softened shadows, borders, and hover motion; gentler/shorter scroll reveal; calmer serif type scale.
- **Smaller headshot**: portrait is now a modest ~120px circular avatar (was a large ~320px panel).
- Updated `theme-color`, favicon, footer line, and the colophon copy to match the new mood.

Verified with a clean local `jekyll build` (zero warnings).

## Test plan

- [ ] Pages build/deploy succeeds from `main` after merge
- [ ] Home reads calm: small circular headshot, no animated decoration, soft mint/mauve accents
- [ ] Light & dark mode both look quiet and legible
- [ ] Interior pages + mobile nav still render correctly

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_