### PR TITLE
Sharpen the bio to research taste

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,7 +27,7 @@ layout: default
     <div class="section-head">
       <p class="kicker">What I&rsquo;m building</p>
       <h2>Research, notes &amp; experiments</h2>
-      <p>A working record of the ideas I&rsquo;m chasing at the intersection of statistics, machine learning, and art.</p>
+      <p>A working record of the path from theory to methodology &mdash; how structural knowledge gets learned, and how it gets deployed.</p>
     </div>
     <div class="grid cols-3">
       {% for c in page.cards %}

--- a/index.md
+++ b/index.md
@@ -2,18 +2,21 @@
 layout: home
 title: Home
 description: >-
-  Yulin Li — Ph.D. candidate in Statistics at Rutgers, working across
-  statistics, machine learning, and music.
+  Yulin Li — Ph.D. candidate in Statistics at Rutgers. How intelligent
+  systems, human or AI, learn and deploy structural knowledge — and the
+  theory that guides methodology in practice.
 
 intro: >-
   I&rsquo;m a Ph.D. candidate in the Department of Statistics at
-  Rutgers&ndash;New Brunswick. I think about inference, machine
-  learning, and the mathematics underneath them &mdash; and, away
-  from the page, I make music.
+  Rutgers&ndash;New Brunswick. I&rsquo;m drawn to one question: how
+  intelligent systems &mdash; human or AI, vision or language &mdash;
+  get to learn and deploy structural knowledge. My work is on the
+  theory that guides methodology in practical deployment. Away from
+  the page, I make music.
 
 facts:
   - "<b>Ph.D. Candidate</b> · Statistics, Rutgers&ndash;New Brunswick"
-  - "<b>Research</b> · inference &amp; machine learning"
+  - "<b>Research</b> · structural knowledge &amp; learning theory"
   - "<b>Music</b> · conductor, arranger, accompanist"
 
 cards:


### PR DESCRIPTION
## Summary

Sharpens the homepage bio to reflect actual research taste, distilled from a personal note — kept calm and concise (the "since middle school" backstory stays in the journal).

- **Intro** now leads with the through-line: *how intelligent systems — human or AI, vision or language — learn and deploy structural knowledge; the theory that guides methodology in practical deployment.*
- Updated the meta `description`, the "Research" fact line, and the work-section copy to match.

Verified with a clean local `jekyll build` (zero warnings).

## Test plan

- [ ] Pages deploy from `main` after merge
- [ ] Home intro reads as the new research statement; meta description updated

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_