### PR TITLE
Fix portrait distortion on mobile

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,7 +17,7 @@ layout: default
     </div>
     <div class="portrait">
       <img src="{{ '/assets/images/2024-rutgers-profile.png' | relative_url }}"
-           alt="Portrait of Yulin Li" loading="eager" width="320" height="320">
+           alt="Portrait of Yulin Li" loading="eager" width="128" height="128">
     </div>
   </div>
 </section>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -163,7 +163,10 @@ img { max-width: 100%; display: block; }
 
 .portrait { justify-self: center; }
 .portrait img {
-  width: clamp(104px, 12vw, 136px); aspect-ratio: 1; object-fit: cover;
+  width: clamp(96px, 22vw, 128px);
+  height: clamp(96px, 22vw, 128px);
+  aspect-ratio: 1 / 1;
+  object-fit: cover; object-position: center 28%;
   border-radius: 50%; border: 1px solid var(--line);
   background: var(--bg-soft);
 }


### PR DESCRIPTION
## Summary

Fixes the hero portrait rendering as a stretched tall ellipse on mobile (per a user screenshot).

**Cause:** the `<img>` carried stale `width="320" height="320"` HTML attributes that conflicted with the responsive CSS. `aspect-ratio` alone didn't win in mobile Safari, so the element took the CSS width but the attribute height — distorting the circle.

**Fix:**
- Pin matching `width="128" height="128"` attributes on the img.
- Set explicit, equal `width`/`height` (clamped, responsive) so it's a guaranteed circle without relying on `aspect-ratio`.
- `object-position: center 28%` to frame the face after cropping.

**Verified** with headless-browser (Playwright/Chromium) screenshots at mobile light, mobile dark, and desktop — portrait now renders as a small, correctly-cropped circle; overall layout calm and on-aesthetic.

## Test plan

- [ ] Pages deploy from `main`
- [ ] Hero portrait is a small circle on mobile (light & dark) and desktop — no distortion

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_