### PR TITLE
community: data-driven feed (category chips + recent posts)

### DIFF
--- a/statsupai-revamp/assets/css/main.css
+++ b/statsupai-revamp/assets/css/main.css
@@ -497,3 +497,22 @@ details.ev-disc .body {
   border: 1px solid var(--line);
 }
 @media (prefers-color-scheme: dark) { .member-monogram { background: rgba(10,156,156,.14); } }
+
+/* Community feed list */
+.co-list { list-style: none; padding: 0; margin: 14px 0 0; }
+.co-post {
+  display: grid; grid-template-columns: 116px 1fr auto; gap: 14px; align-items: baseline;
+  padding: 12px 4px; border-bottom: 1px solid var(--line);
+}
+.co-post a { color: var(--ink); font-weight: 600; }
+.co-post a:hover { color: var(--accent); }
+.co-date { color: var(--muted); font-size: .85rem; font-variant-numeric: tabular-nums; }
+.co-cat {
+  font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  color: var(--accent); background: var(--teal-050); padding: 3px 9px; border-radius: 999px;
+}
+@media (prefers-color-scheme: dark) { .co-cat { background: rgba(10,156,156,.14); } }
+@media (max-width: 640px) {
+  .co-post { grid-template-columns: 1fr; gap: 4px; }
+  .co-cat { justify-self: start; }
+}

--- a/statsupai-revamp/assets/data/community.json
+++ b/statsupai-revamp/assets/data/community.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Community feed mirror of the live Quarto posts index (statsupai.org/quarto_web/site/posts/). Categories + recent posts from _reference survey. Deep-links out (no iframe). Refresh recent[] periodically or when notable posts ship.",
+  "feed": "https://statsupai.org/quarto_web/site/posts/index.html",
+  "base": "https://statsupai.org/quarto_web/site/posts/",
+  "total": 73,
+  "categories": [
+    { "name": "Events", "count": 29 },
+    { "name": "Interviews", "count": 24 },
+    { "name": "Opportunities", "count": 13 },
+    { "name": "Resources", "count": 12 },
+    { "name": "Videos", "count": 11 },
+    { "name": "Announcements", "count": 6 },
+    { "name": "Webinars", "count": 6 }
+  ],
+  "recent": [
+    { "title": "BIOS 740: Deep Learning Methods in Biomedical Sciences with PyTorch", "date": "2026-05-03", "cat": "Resources", "file": "bios740-course.html" },
+    { "title": "The ICML 2023 Ranking Experiment: Author Self-Assessment in ML/AI Peer Review", "date": "2026-04-14", "cat": "Interviews", "file": "icml2023-ranking-experiment.html" },
+    { "title": "In Conversation with Bingxin Zhao: Agentic AI for Genetic Discovery", "date": "2026-03-08", "cat": "Interviews", "file": "agentic-ai-genetics-interview.html" },
+    { "title": "Emerging Knowledge Trend in Statistical Research", "date": "2026-03-08", "cat": "Interviews", "file": "emerging-knowledge-trend.html" },
+    { "title": "StatsUpAI Interest Group Announces 2026 Election Results & Executive Committee", "date": "2026-02-21", "cat": "Announcements", "file": "2026-ec-election.html" },
+    { "title": "SMI 2026 Announcement", "date": "2026-02-03", "cat": "Events", "file": "2026-smi-announcement.html" },
+    { "title": "Workshop: Statistical Foundations of AI", "date": "2026-02-02", "cat": "Events", "file": "uncertainty_workshop.html" },
+    { "title": "In Conversation: Cancer Transcriptomic Deconvolution", "date": "2026-01-28", "cat": "Interviews", "file": "cancer_review.html" },
+    { "title": "Rebuilding Statistics in the Age of AI", "date": "2026-01-27", "cat": "Interviews", "file": "perspective_paper.html" },
+    { "title": "StatsUpAI · 2025 Annual Newsletter", "date": "2025-12-31", "cat": "Announcements", "file": "2025-annual-newsletter.html" },
+    { "title": "LAMBDA: A Large Model Based Data Agent", "date": "2025-11-24", "cat": "Interviews", "file": "LAMBDA.html" },
+    { "title": "2025 Workshop at BIRS: Day 4 Recordings", "date": "2025-08-21", "cat": "Videos", "file": "2025-birs-workshop-day-4.html" },
+    { "title": "2025 Workshop at BIRS: Day 3 Recordings", "date": "2025-08-20", "cat": "Videos", "file": "2025-birs-workshop-day-3.html" },
+    { "title": "2025 Workshop at BIRS: Day 2 Recordings", "date": "2025-08-20", "cat": "Videos", "file": "2025-birs-workshop-day-2.html" },
+    { "title": "2025 Workshop at BIRS: Day 1 Recordings", "date": "2025-08-19", "cat": "Videos", "file": "2025-birs-workshop-day-1.html" }
+  ]
+}

--- a/statsupai-revamp/assets/js/render.js
+++ b/statsupai-revamp/assets/js/render.js
@@ -102,6 +102,34 @@
     }).catch(function () { /* keep noscript fallback */ });
   }
 
+  /* ---------------- Community feed ---------------- */
+  var coRoot = document.querySelector("[data-community]");
+  if (coRoot) {
+    getJSON("assets/data/community.json").then(function (c) {
+      var chips = c.categories.map(function (k) {
+        return '<a class="chip" href="' + esc(c.feed) + '" target="_blank" rel="noopener">' +
+          esc(k.name) + ' <b>' + k.count + "</b></a>";
+      }).join("");
+      var posts = c.recent.map(function (p) {
+        return '<li class="co-post">' +
+          '<span class="co-date">' + new Date(p.date + "T00:00:00").toLocaleDateString("en-US",
+            { month: "short", day: "numeric", year: "numeric" }) + "</span>" +
+          '<a href="' + esc(c.base + p.file) + '" target="_blank" rel="noopener">' + esc(p.title) + "</a>" +
+          '<span class="co-cat">' + esc(p.cat) + "</span></li>";
+      }).join("");
+      coRoot.innerHTML = "";
+      var wrap = el("div");
+      wrap.innerHTML =
+        '<div class="res-filters" style="margin-bottom:26px">' + chips + "</div>" +
+        '<div class="ev-series-head"><h2>Latest posts</h2><span class="sub">' +
+        c.total + " in the feed</span></div>" +
+        '<ul class="co-list">' + posts + "</ul>" +
+        '<p style="margin-top:22px"><a class="btn btn-primary" href="' + esc(c.feed) +
+        '" target="_blank" rel="noopener">Browse the full community feed ↗</a></p>';
+      coRoot.appendChild(wrap);
+    }).catch(function () { /* keep noscript fallback */ });
+  }
+
   /* ---------------- Review Articles (Zotero-driven) ---------------- */
   var arRoot = document.querySelector("[data-articles]");
   if (arRoot) {

--- a/statsupai-revamp/community.html
+++ b/statsupai-revamp/community.html
@@ -39,44 +39,22 @@
   <div class="container page-head">
     <p class="crumb"><a href="index.html">Home</a> → Community News</p>
     <h1>Community News</h1>
-    <p>Timely funding, awards and training opportunities for statisticians in AI — plus
-    interviews and newsletters from the community.</p>
+    <p>Announcements, interviews, opportunities, resources and recorded events
+    from the StatsUpAI community — 73 posts and counting. Each links straight
+    to the full post (shareable and indexable, not framed).</p>
   </div>
 
   <section class="block">
     <div class="container">
-      <div class="grid cols-3">
-        <article class="card">
-          <div class="ico" aria-hidden="true">✦</div>
-          <h3>Interviews</h3>
-          <p>Conversations with statisticians and data scientists working at the frontier
-          of AI research and applications.</p>
-          <a class="more" href="https://statsupai.org/community-news.html" target="_blank" rel="noopener">Read interviews</a>
-        </article>
-        <article class="card">
-          <div class="ico" aria-hidden="true">◷</div>
-          <h3>Annual Newsletters</h3>
-          <p>Yearly roundups of community milestones, new resources and the growing
-          interest group.</p>
-          <a class="more" href="https://statsupai.org/community-news.html" target="_blank" rel="noopener">Browse newsletters</a>
-        </article>
-        <article class="card">
-          <div class="ico" aria-hidden="true">★</div>
-          <h3>Funding &amp; Awards</h3>
-          <p>Curated funding calls, awards and specialized training programs tailored for
-          statisticians in AI.</p>
-          <a class="more" href="https://groups.google.com/g/stats-up-ai/" target="_blank" rel="noopener">Get updates</a>
-        </article>
-      </div>
-
-      <hr class="div">
-
-      <div class="prose">
-        <p>The live community feed is published via the project's long-form posts. The
-        original site embeds it in a fixed-height frame; this revamp links out directly so
-        each post renders full-width with its own navigation and is independently
-        shareable and indexable.</p>
-        <p><a class="btn btn-primary" href="https://statsupai.org/community-news.html" target="_blank" rel="noopener">Open the full community feed</a></p>
+      <div data-community="1">
+        <noscript>
+          <ul>
+            <li><a href="https://statsupai.org/quarto_web/site/posts/index.html">Browse the full community feed (73 posts)</a></li>
+            <li><a href="https://statsupai.org/quarto_web/site/posts/bios740-course.html">BIOS 740: Deep Learning Methods in Biomedical Sciences (May 2026)</a></li>
+            <li><a href="https://statsupai.org/quarto_web/site/posts/2026-ec-election.html">2026 Election Results &amp; Executive Committee</a></li>
+            <li><a href="https://statsupai.org/quarto_web/site/posts/2025-annual-newsletter.html">StatsUpAI · 2025 Annual Newsletter</a></li>
+          </ul>
+        </noscript>
       </div>
     </div>
   </section>
@@ -108,6 +86,7 @@
 </footer>
 
 <script src="assets/js/analytics.js" defer></script>
+<script src="assets/js/render.js" defer></script>
 <script src="assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Community News enrichment (#15). `community.json` mirrors the live Quarto
posts index (73 posts; 7 categories with counts; 15 most-recent). Renderer:
category chips (with counts, linking to the feed) + a clean recent-posts
list (date · title→post · category chip), each deep-linking to the full
post (no iframe — shareable/indexable); full-feed CTA; noscript fallback.
Replaces the old placeholder 3-card block with the real feed.

CI green. Remaining branch work largely complete; next: final polish &
status summary.

https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrnNt9H8vjrqMCGvwFbtYa)_