### PR TITLE
Music: pianist over conductor; link MA 751 course

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,7 +67,7 @@ layout: default
     <div class="section-head">
       <p class="kicker">Off the page</p>
       <h2>A life in music</h2>
-      <p>Conductor, music director, arranger, and accompanist &mdash; building choirs and concerts wherever I go.</p>
+      <p>Pianist, music director, arranger, and accompanist &mdash; building choirs and concerts wherever I go.</p>
     </div>
     <div class="timeline">
       {% for m in page.music %}

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ intro: >-
 facts:
   - "<b>Ph.D. Candidate</b> · Statistics, Rutgers&ndash;New Brunswick"
   - "<b>Research</b> · structural knowledge &amp; learning theory"
-  - "<b>Music</b> · conductor, arranger, accompanist"
+  - "<b>Music</b> · pianist, arranger, accompanist"
 
 cards:
   - icon: "✦"
@@ -63,7 +63,7 @@ teaching:
     detail: "Teaching Assistant, Department of Statistics, Rutgers University."
   - when: "Spring 2023 · Boston University"
     course: "MA 751 — Statistical Machine Learning"
-    detail: "Teaching Assistant, Department of Math &amp; Statistics. Recitations 2 hr/wk · class size ~20."
+    detail: "Sole Teaching Assistant, Department of Math &amp; Statistics &mdash; a demanding PhD-level course. <a href='https://math.bu.edu/people/mkon/MA751/index.html'>Course page</a>."
   - when: "Spring 2022 · Boston University"
     course: "MA 575 — Linear Models"
     detail: "Teaching Assistant across five sections. Recitations 5 hr/wk · class size ~80."


### PR DESCRIPTION
## Summary

- **Music framing:** conductor → **pianist** in the hero fact chip and the music section intro (keeps the event timeline factual, where she genuinely was conductor).
- **MA 751 (Statistical Machine Learning):** the Boston University teaching entry now notes the **sole-TA** role on a demanding PhD-level course and links the official course page: https://math.bu.edu/people/mkon/MA751/index.html

**Verified** with a headless-browser screenshot of the hero (fact chip reads "Music · pianist, arranger, accompanist") and the teaching timeline (MA 751 shows the linked course page); portrait still renders as a clean small circle.

## Test plan

- [ ] Pages deploy from `main`
- [ ] Hero music chip says "pianist"; MA 751 entry links the BU course page

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_