### PR TITLE
Scratch Toolbox; repoint Reference Library to AI collections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,6 @@ nav:
   - { name: "Research",  url: "/docs/" }
   - { name: "Library",   url: "/reading/" }
   - { name: "Projects",  url: "/projects/" }
-  - { name: "Toolbox",   url: "/toolbox/" }
 
 social:
   github: "yulinl2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,5 +24,5 @@ keep.
 
 ## Related
 
-- The **[Reference Library](../reading/)** — annotated paper notes and reading roadmaps.
+- The **[AI Reference Library](../reading/)** — curated literature collections on LLMs, AI safety, and agents.
 - The **[AI × Stat/Math Lit Review](../ai4statmath-litreview/)** — a living literature map.

--- a/index.md
+++ b/index.md
@@ -27,11 +27,11 @@ cards:
     tags: ["Statistics", "Machine Learning"]
     cta: "Read the notes"
   - icon: "❑"
-    title: "Reference Library"
-    body: "An annotated record of papers I&rsquo;ve read — key insights, open questions, and reading roadmaps."
+    title: "AI Reference Library"
+    body: "Curated, annotated literature collections on large language models, AI safety &amp; fairness, and AGI &amp; agents."
     url: "/reading/"
-    tags: ["Papers", "Roadmaps"]
-    cta: "Browse the library"
+    tags: ["LLMs", "AI Safety", "Agents"]
+    cta: "Browse the collections"
   - icon: "◇"
     title: "AI × Stat/Math Lit Review"
     body: "A living literature map tracking the conversation between modern AI and the statistical & mathematical foundations it leans on."
@@ -50,12 +50,6 @@ cards:
     url: "/cvocaloid-observatory/"
     tags: ["Data", "Music"]
     cta: "Visit the dashboard"
-  - icon: "⌥"
-    title: "Toolbox"
-    body: "Prompts, workflows, and scratch notes — the working scaffolding behind everything else here."
-    url: "/toolbox/"
-    tags: ["Workflow", "Notes"]
-    cta: "Open the toolbox"
 
 teaching:
   - when: "Fall 2024 · Rutgers"

--- a/reading/index.md
+++ b/reading/index.md
@@ -1,20 +1,17 @@
 ---
-title: Reference Library
-description: Annotated notes on papers I've read — insights, open questions, and reading roadmaps.
+title: AI Reference Library
+description: Curated, annotated literature collections on LLMs, AI safety & fairness, and AGI & agents.
 ---
 
-Each paper gets its own page: what it claims, what convinced me, and
-the questions I left with.
+Rather than keep notes scattered, I maintain a few living,
+annotated literature collections — organized by theme, kept current
+as the field moves. These live on the StatsUpAI platform:
 
-## Inference on inference
+- **[Large Language Models](https://statsupai.org/pages/paper_list_ai/list-AI-LLM.html)**
+  — an overview collection tracking the LLM literature.
 
-- **[Confidence set for discrete argmin](./2025-01-12-argmin-inference.md)**
-  — Zhang et al. (2024), *Winners with Confidence: Discrete Argmin
-  Inference with an Application to Model Selection*.
-  [arXiv:2408.02060](https://arxiv.org/abs/2408.02060)
+- **[AI Safety, Privacy &amp; Fairness](https://statsupai.org/pages/paper_list_ai/list-AI-Safety.html)**
+  — work on safety, trustworthiness, privacy, and fairness.
 
-- **[Comparative model evaluations](./2025-01-14-comparative-eval.md)**
-  — Su et al. (2024), *Analysis of the ICML 2023 Ranking Data: Can
-  Authors&rsquo; Opinions of Their Own Papers Assist Peer Review in
-  Machine Learning?*
-  [arXiv:2408.13430](https://arxiv.org/abs/2408.13430)
+- **[AGI &amp; AI Agents](https://statsupai.org/pages/paper_list_ai/list-AI-Agent.html)**
+  — toward general intelligence, and agentic systems.


### PR DESCRIPTION
## Summary

The Toolbox and the original paper-notes library were envisioned but never really built (visible in early commit history). This cleans that up honestly:

- **Toolbox**: removed the homepage card and the nav/footer link.
- **Reference Library → AI Reference Library**: repurposed the page (and card) as pointers to the three AI literature collections actually built on StatsUpAI:
  - [Large Language Models](https://statsupai.org/pages/paper_list_ai/list-AI-LLM.html)
  - [AI Safety, Privacy & Fairness](https://statsupai.org/pages/paper_list_ai/list-AI-Safety.html)
  - [AGI & AI Agents](https://statsupai.org/pages/paper_list_ai/list-AI-Agent.html)
- Tidied a stale cross-reference in the Research page.

**Verified** with headless-browser screenshots: 5-card grid (no Toolbox), nav = Research/Library/Projects, and the repurposed library page rendering the three pointers cleanly.

## Test plan

- [ ] Pages deploy from `main`
- [ ] No Toolbox in nav/footer/cards; Library page shows the three StatsUpAI AI collections

https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqeQ2GJc3P1ZKnLHMVEBDZ)_